### PR TITLE
Register the AutoGluon 1.6 presets as official TabArena methods

### DIFF
--- a/packages/tabarena/src/tabarena/contexts/tabarena/_tabarena_method_metadata_2026_08_05.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/_tabarena_method_metadata_2026_08_05.py
@@ -1,0 +1,40 @@
+"""Method metadata for the ``tabarena-2026-08-05`` suite: the released AutoGluon 1.6 presets.
+
+The AutoGluon 1.6 release runs on TabArena-Full (816 tasks over 51 datasets), fit with the shipped
+presets and a 4 hour per-task time limit. ``compute`` is set manually: the runs were on one GPU per
+task, but the raw results record ``num_gpus=0``, so the inferred value would be wrong.
+"""
+
+from __future__ import annotations
+
+from tabarena.models._method_metadata import MethodMetadata
+
+_common_kwargs = dict(
+    suite="tabarena-2026-08-05",
+    date="2026-08-05",
+    compute="gpu",
+    date_introduced="2026-08",  # AutoGluon 1.6 release
+    reference_url="https://arxiv.org/abs/2003.06505",
+    verified=True,
+    cache_type="r2",
+    cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
+)
+
+ag_160_eq_4h_metadata = MethodMetadata.baseline(
+    method="AutoGluon_16_extreme",
+    name="AutoGluon 1.6 (extreme, 4h)",
+    **_common_kwargs,
+)
+
+# The `noncommercial` preset: `extreme_quality` plus TabPFN-3, whose license is not commercially
+# permissive; the entry itself carries no license flag (MethodMetadata has none), the name does.
+ag_160_noncomm_4h_metadata = MethodMetadata.baseline(
+    method="AutoGluon_16_noncommercial",
+    name="AutoGluon 1.6 (noncommercial, 4h)",
+    **_common_kwargs,
+)
+
+methods_2026_08_05_ag: list[MethodMetadata] = [
+    ag_160_eq_4h_metadata,
+    ag_160_noncomm_4h_metadata,
+]

--- a/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
@@ -26,6 +26,10 @@ from tabarena.contexts.tabarena._tabarena_method_metadata_2026_01_23_tabprep imp
     tabprep_realtabpfnv250_metadata,
     tabprep_tabm_metadata,
 )
+from tabarena.contexts.tabarena._tabarena_method_metadata_2026_08_05 import (
+    ag_160_eq_4h_metadata,
+    ag_160_noncomm_4h_metadata,
+)
 from tabarena.contexts.tabarena._tabarena_method_metadata_misc import (
     gbm_aio_0808_metadata,
     # prep_gbm_v6_metadata,
@@ -144,6 +148,8 @@ tabarena_method_metadata_collection = MethodMetadataCollection(
         # AutoGluon
         ag_140_bq_4h8c_metadata,
         ag_150_eq_4h8c_metadata,
+        ag_160_eq_4h_metadata,
+        ag_160_noncomm_4h_metadata,
         # Default tabular models (CPU)
         catboost_new_method_metadata,
         chimeraboost_new_method_metadata,


### PR DESCRIPTION
## What

Adds the `tabarena-2026-08-05` suite metadata (`_tabarena_method_metadata_2026_08_05.py`) for the released AutoGluon 1.6 presets and registers both in `tabarena_method_metadata_collection`:

* **AutoGluon 1.6 (extreme, 4h)** (`AutoGluon_16_extreme`)
* **AutoGluon 1.6 (noncommercial, 4h)** (`AutoGluon_16_noncommercial`)

Both are TabArena-Full runs (816 tasks over 51 datasets, all splits) of the shipped `extreme` / `noncommercial` presets with only the fit `time_limit` raised to 4 hours, matching the "AutoGluon 1.5 (extreme, 4h)" naming convention.

<img width="6150" height="810" alt="tuning-impact-elo_8" src="https://github.com/user-attachments/assets/61eb9944-e72c-40b9-8173-20d59c006ef9" />

## Artifacts

Processed and uploaded to the r2 cache: each method has the full object set under `cache/artifacts/tabarena-2026-08-05/methods/<Method>/` (`metadata.yaml`, `processed.zip`, `processed/configs_hyperparameters.json`, `raw.zip`, `results/model_results.parquet`), verified via bucket listing after the upload. `verified=True` is set in the metadata.

## Notes

* `compute="gpu"` is a deliberate manual override: the runs used one GPU per task, but the raw results record `num_gpus=0`, so the inferred value (`cpu`) would be wrong. Processing ran with `--ignore-metadata-mismatch` for exactly this field; everything else matched the raw-data inference.
* On the regenerated TabArena-Full leaderboard, noncommercial places first overall (1789 Elo, ahead of TabFM at 1765) and extreme third (1737).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi