### PR TITLE
fix: handle pd.NA in `string` columns that AsType bool-encodes

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/model_agnostic_default_preprocessing.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/model_agnostic_default_preprocessing.py
@@ -267,6 +267,17 @@ class StringFixAsTypeFeatureGenerator(AsTypeFeatureGenerator):
 
     def _transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Override the default handling for unseen values!"""
+        # Needed here too, but only for the features that were bool-encoded at fit time: such a column
+        # can gain nulls at test time that fit never saw, and the bool encoding below would then raise
+        # "cannot convert NA to integer".
+        X = self._fill_nulls_for_bool_encoding(
+            X,
+            [
+                col
+                for col in self._bool_features
+                if col in X.columns and isinstance(X[col].dtype, pd.StringDtype) and X[col].isna().any()
+            ],
+        )
         if self._bool_features:
             X = self._handle_bool_cols_with_unseen_values_at_test_time(X)
 
@@ -280,8 +291,58 @@ class StringFixAsTypeFeatureGenerator(AsTypeFeatureGenerator):
 
         return X
 
+    @staticmethod
+    def _string_columns_about_to_be_bool_encoded(X: pd.DataFrame) -> list[str]:
+        """`string` columns that AsType will bool-encode AND that contain nulls.
+
+        Mirrors the condition in ``AsTypeFeatureGenerator._fit_transform``: a feature is bool-encoded
+        when ``len(X[feature].unique()) == 2``. That is the only path that reaches
+        ``get_bool_true_val``, so it is the only path that can hit the pd.NA problem, and therefore the
+        only path where anything needs to be changed.
+        """
+        return [
+            col
+            for col in X.columns
+            if isinstance(X[col].dtype, pd.StringDtype) and X[col].isna().any() and len(X[col].unique()) == 2
+        ]
+
+    @staticmethod
+    def _fill_nulls_for_bool_encoding(X: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
+        """Replace nulls with a placeholder string in columns that are about to become booleans.
+
+        ``AsTypeFeatureGenerator`` bool-encodes any column with exactly two unique values. For a pandas
+        ``string`` column holding one real value plus nulls those uniques are ``[value, pd.NA]``, and
+        ``get_bool_true_val`` then evaluates ``np.isnan(pd.NA)``, which *returns* ``pd.NA`` rather than
+        raising -- so its ``except (ValueError, TypeError)`` never fires and the following
+        ``if is_nan:`` raises ``TypeError: boolean value of NA is ambiguous``. Where that branch is
+        passed instead, the subsequent ``(X[col] == true_val).astype(np.int8)`` raises
+        ``ValueError: cannot convert NA to integer`` on the masked comparison.
+
+        An ``object`` column is unaffected because ``np.isnan(np.nan)`` is a real ``True``. It is
+        specifically the nullable ``string`` dtype -- which this class deliberately marks as text so it
+        reaches the text generators -- that trips it.
+
+        Nothing is lost by filling *these* columns: they are on their way to becoming ``int8``, which
+        cannot hold a null anyway, and AutoGluon already defines nulls in a bool feature as ``False``
+        ("Any new unseen values (including nan) at inference time will be mapped to `False`
+        automatically", ``get_bool_true_val``). The placeholder is chosen so it cannot collide with the
+        column's single real value, which keeps the unique count at two and the encoding unchanged.
+
+        Columns that are NOT bool-encoded keep their nulls, so text and categorical features still see
+        missing values as missing.
+        """
+        if not columns:
+            return X
+        X = X.copy()
+        for col in columns:
+            real_values = set(X[col].dropna().unique())
+            placeholder = "" if "" not in real_values else "__NA__"
+            X[col] = X[col].fillna(placeholder)
+        return X
+
     def _fit_transform(self, X: pd.DataFrame, **kwargs) -> tuple[pd.DataFrame, dict]:
         # X arrives here with '.' already replaced by '_' (done in TabArenaModelAgnosticPreprocessing.fit_transform).
+        X = self._fill_nulls_for_bool_encoding(X, self._string_columns_about_to_be_bool_encoded(X))
         X, type_group_map_special = super()._fit_transform(X=X, **kwargs)
 
         found_text_cols = type_group_map_special.get("text", [])

--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -2627,8 +2627,7 @@ class LeaderboardReporter:
             # `plot_tune_types` selects among the standard default/tuned/... bars.
             override_tune_types = [ov.tune_method for ov in tune_method_overrides]
             df = df[
-                df["tune_method"].isin([*plot_tune_types, *override_tune_types])
-                | df[self.method_col].isin(baselines)
+                df["tune_method"].isin([*plot_tune_types, *override_tune_types]) | df[self.method_col].isin(baselines)
             ]
 
         df_plot = df[df["framework_type"].isin(framework_types)]

--- a/tests/tabarena/benchmark/preprocessing/test_preprocessing.py
+++ b/tests/tabarena/benchmark/preprocessing/test_preprocessing.py
@@ -492,6 +492,84 @@ class TestStringFixAsTypeFeatureGenerator:
 
 
 # ===========================================================================
+# StringFixAsTypeFeatureGenerator – nulls in pandas `string` columns
+# ===========================================================================
+
+
+class TestStringFixAsTypeFeatureGeneratorStringNulls:
+    """Tests for nulls in pandas `string` columns reaching AsType's bool encoding.
+
+    AsTypeFeatureGenerator bool-encodes any column with exactly two unique values. For a `string`
+    column holding one real value plus nulls those uniques are ``[value, pd.NA]``, which used to raise
+    ``TypeError: boolean value of NA is ambiguous`` (or ``ValueError: cannot convert NA to integer``)
+    from AutoGluon's ``get_bool_true_val``.
+    """
+
+    def test_fit_transform_with_single_value_string_column_and_nulls(self):
+        """The exact crash: a `string` column whose uniques are one value plus pd.NA."""
+        X = pd.DataFrame({"num": [1.0, 2.0, 3.0, 4.0]})
+        X["flag"] = pd.array(["ONLY", "ONLY", None, None], dtype="string")
+        assert len(X["flag"].unique()) == 2
+
+        X_out = StringFixAsTypeFeatureGenerator().fit_transform(X.copy())
+        assert "flag" in X_out.columns
+        # It becomes a bool feature, so the nulls are False -- AutoGluon's documented behaviour for
+        # bool features, and an int8 column cannot hold a null in any case.
+        assert X_out["flag"].isna().sum() == 0
+        assert set(X_out["flag"].unique()) <= {0, 1}
+
+    def test_transform_when_bool_encoded_string_column_gains_nulls(self):
+        """Nulls can appear at test time in a bool-encoded column that had none during fit."""
+        X_train = pd.DataFrame({"num": [1.0, 2.0, 3.0, 4.0]})
+        X_train["flag"] = pd.array(["a", "b", "a", "b"], dtype="string")
+        gen = StringFixAsTypeFeatureGenerator()
+        gen.fit_transform(X_train.copy())
+        assert "flag" in gen._bool_features
+
+        X_test = pd.DataFrame({"num": [5.0, 6.0]})
+        X_test["flag"] = pd.array(["a", None], dtype="string")
+        X_out = gen.transform(X_test.copy())
+        assert len(X_out) == 2
+        assert X_out["flag"].isna().sum() == 0
+
+    def test_nulls_are_kept_in_string_columns_that_are_not_bool_encoded(self):
+        """Only the bool-encoding path is touched; every other column keeps its missing values."""
+        values = [f"some free text number {i}" for i in range(20)]
+        X = pd.DataFrame({"num": list(range(20))})
+        X["txt"] = pd.array(values, dtype="string")
+        X.loc[0:4, "txt"] = pd.NA
+        assert len(X["txt"].unique()) > 2
+
+        X_out = StringFixAsTypeFeatureGenerator().fit_transform(X.copy())
+        assert X_out["txt"].isna().sum() == 5, "nulls must survive in a column that is not a bool"
+        assert "txt" in X_out.columns
+
+    def test_multi_value_string_column_with_nulls_is_still_text(self):
+        """Filling must not change how a genuine text column is classified."""
+        values = [f"some free text number {i}" for i in range(20)]
+        X = pd.DataFrame({"num": list(range(20))})
+        X["txt"] = pd.array(values, dtype="string")
+        X.loc[0:4, "txt"] = pd.NA
+
+        gen = StringFixAsTypeFeatureGenerator()
+        gen.fit_transform(X.copy())
+        assert "txt" in gen.feature_metadata_in.get_features(required_special_types=["text"])
+
+    def test_placeholder_cannot_collide_with_the_real_value(self):
+        """An empty string as the real value must not collapse the column to one unique."""
+        X = pd.DataFrame({"num": [1.0, 2.0, 3.0, 4.0]})
+        X["flag"] = pd.array(["", "", None, None], dtype="string")
+        filled = StringFixAsTypeFeatureGenerator._fill_nulls_for_bool_encoding(X, ["flag"])
+        assert len(filled["flag"].unique()) == 2, "the two-value structure must be preserved"
+
+    def test_frames_without_bool_candidate_string_nulls_are_untouched(self):
+        """No candidate columns means the input object is returned as-is."""
+        X = pd.DataFrame({"a": pd.array(["x", "y"], dtype="string"), "b": [1.0, 2.0]})
+        assert StringFixAsTypeFeatureGenerator._string_columns_about_to_be_bool_encoded(X) == []
+        assert StringFixAsTypeFeatureGenerator._fill_nulls_for_bool_encoding(X, []) is X
+
+
+# ===========================================================================
 # StringFixAsTypeFeatureGenerator – categorical dtype special cases
 # ===========================================================================
 


### PR DESCRIPTION
## Issue

`AsTypeFeatureGenerator` bool-encodes any column with exactly two unique values. For a pandas **`string`** column holding one real value plus nulls, those uniques are `[value, pd.NA]`, and AutoGluon's `get_bool_true_val` then evaluates `np.isnan(pd.NA)` — which *returns* `pd.NA` rather than raising. Its `except (ValueError, TypeError)` therefore never fires, and the following `if is_nan:` raises:

```
TypeError: boolean value of NA is ambiguous
```

Where that branch happens to be passed instead, the subsequent `(X[col] == true_val).astype(np.int8)` raises `ValueError: cannot convert NA to integer` on the masked comparison. Same trigger, two exits.

An `object` column is unaffected, because `np.isnan(np.nan)` is a real `True`. It is specifically the nullable `string` dtype — which `StringFixAsTypeFeatureGenerator._fit_transform` deliberately force-marks as text so it reaches the text generators — that trips it.

This is easy to hit on wide real-world tables: any mostly-empty text column with a single distinct value crashes the whole `fit_transform`. We saw it on ~5 of 273 SAP/CDH tasks (tables with 18 and 227 `string` columns).

### Reproduction

```python
import pandas as pd
from tabarena.benchmark.preprocessing.model_agnostic_default_preprocessing import (
    StringFixAsTypeFeatureGenerator,
)

X = pd.DataFrame({"num": [1.0, 2.0, 3.0, 4.0]})
X["flag"] = pd.array(["ONLY", "ONLY", None, None], dtype="string")   # uniques == ['ONLY', <NA>]

StringFixAsTypeFeatureGenerator().fit_transform(X)
# TypeError: boolean value of NA is ambiguous
```

## Fix

Fill nulls with a placeholder string in **exactly** the columns that are about to be bool-encoded, and only those:

* in `_fit_transform`, the `string` columns with two uniques — mirroring the condition in `AsTypeFeatureGenerator._fit_transform`, which is the only path that reaches `get_bool_true_val` and therefore the only path that can hit this;
* in `_transform`, the `string` columns already in `self._bool_features`, since such a column can gain nulls at test time that fit never saw.

**Missing values are preserved everywhere else.** Text and categorical features still see nulls as nulls; only the columns on their way to becoming `int8` are touched.

Nothing is lost for those columns either: `int8` cannot hold a null, and AutoGluon already defines nulls in a bool feature as `False` — *"Any new unseen values (including nan) at inference time will be mapped to `False` automatically"* (`get_bool_true_val`). The placeholder is chosen so it cannot collide with the column's single real value, which keeps the unique count at two and leaves the encoding unchanged.

On placement: the sibling `_handle_nan_in_int_only_at_test_time` / `_handle_bool_cols_with_unseen_values_at_test_time` / `_handle_dtype_mismatch_at_test_time` methods cover the same family of nullable-dtype problems, but all three run in `_transform` only. This crash happens in `_fit_transform`, which calls straight through to the unmodified `AsTypeFeatureGenerator`.

## Relationship to the AutoGluon bug

The root cause is in AutoGluon (`get_bool_true_val` using `np.isnan` instead of `pd.isna`) and is being filed separately. This fix is still worth having on its own: tabarena installs AutoGluon from PyPI, so it would otherwise stay broken until a release ships the upstream fix.

Verified independently — with the AutoGluon fix reverted, the new tests pass with this change; against unpatched upstream, 4 of the 6 fail.

## Tests

Added `TestStringFixAsTypeFeatureGeneratorStringNulls` to `tests/tabarena/benchmark/preprocessing/test_preprocessing.py`:

- the exact crash during `fit_transform`, asserting the result is a clean 0/1 bool feature
- a bool-encoded column that gains nulls only at test time
- **nulls survive in a `string` column that is not bool-encoded** (the guard that this fix stays narrow)
- a genuine multi-value text column with nulls is still classified as text
- the placeholder cannot collide with the real value (an empty-string column stays two-valued)
- a frame with no candidate columns is returned unchanged

All 201 tests in `tests/tabarena/benchmark/preprocessing/` pass. `ruff check` and `ruff format --check` are clean under the repo config.

---

### Unrelated second commit: `ruff format` on `leaderboard_reporter.py`

`main` is currently failing the `Ruff format check` CI step, so this PR could not
go green on its own. The pinned formatter (`ruff==0.14.0`) wants one boolean
expression in `LeaderboardReporter._plot_bars` re-wrapped onto a single line
(118 chars); it came in with #474. The second commit is just that re-wrap —
formatting only, no behaviour change — and is easy to drop if you would rather
fix it separately on `main`.
