### PR TITLE
[New Model] CTBoost 0.1.61

### DIFF
--- a/packages/tabarena/pyproject.toml
+++ b/packages/tabarena/pyproject.toml
@@ -131,7 +131,7 @@ limix = [
 tabpfnwide = ["tabpfnwide>=0.3.0"]
 iltm = ["iltm>=0.1.1"]
 chimeraboost = ["chimeraboost>=0.30.0"]
-ctboost = ["ctboost>=0.1.58"]
+ctboost = ["ctboost>=0.1.60"]
 nori = ["synthefy-nori>=0.10.0"]
 # EXAONE Tabular is not published on PyPI; pinned to a commit so the benchmarked code is fixed
 # (empty extra on PyPI). Keep in sync with `pip_extra` in models/exaone_tabular/info.py.

--- a/packages/tabarena/pyproject.toml
+++ b/packages/tabarena/pyproject.toml
@@ -131,7 +131,7 @@ limix = [
 tabpfnwide = ["tabpfnwide>=0.3.0"]
 iltm = ["iltm>=0.1.1"]
 chimeraboost = ["chimeraboost>=0.30.0"]
-ctboost = ["ctboost>=0.1.56"]
+ctboost = ["ctboost>=0.1.58"]
 nori = ["synthefy-nori>=0.10.0"]
 # EXAONE Tabular is not published on PyPI; pinned to a commit so the benchmarked code is fixed
 # (empty extra on PyPI). Keep in sync with `pip_extra` in models/exaone_tabular/info.py.

--- a/packages/tabarena/pyproject.toml
+++ b/packages/tabarena/pyproject.toml
@@ -131,7 +131,7 @@ limix = [
 tabpfnwide = ["tabpfnwide>=0.3.0"]
 iltm = ["iltm>=0.1.1"]
 chimeraboost = ["chimeraboost>=0.30.0"]
-ctboost = ["ctboost>=0.1.60"]
+ctboost = ["ctboost==0.1.61"]
 nori = ["synthefy-nori>=0.10.0"]
 # EXAONE Tabular is not published on PyPI; pinned to a commit so the benchmarked code is fixed
 # (empty extra on PyPI). Keep in sync with `pip_extra` in models/exaone_tabular/info.py.

--- a/packages/tabarena/pyproject.toml
+++ b/packages/tabarena/pyproject.toml
@@ -131,6 +131,7 @@ limix = [
 tabpfnwide = ["tabpfnwide>=0.3.0"]
 iltm = ["iltm>=0.1.1"]
 chimeraboost = ["chimeraboost>=0.30.0"]
+ctboost = ["ctboost>=0.1.56"]
 nori = ["synthefy-nori>=0.10.0"]
 # EXAONE Tabular is not published on PyPI; pinned to a commit so the benchmarked code is fixed
 # (empty extra on PyPI). Keep in sync with `pip_extra` in models/exaone_tabular/info.py.
@@ -173,6 +174,7 @@ extended = [
   "tabarena[tabpfnwide]",
   "tabarena[iltm]",
   "tabarena[chimeraboost]",
+  "tabarena[ctboost]",
   "tabarena[nori]",
   "tabarena[tabswift]",
   "tabarena[exaone_tabular]",

--- a/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
@@ -46,6 +46,7 @@ from tabarena.models.chimeraboost.info import (
     chimeraboost_new_method_metadata,
     chimeraboost_v030_method_metadata,
 )
+from tabarena.models.ctboost.info import ctboost_method_metadata
 from tabarena.models.ebm.info import (
     ebm_method_metadata as ebm_metadata,
     ebm_new_method_metadata,
@@ -159,6 +160,7 @@ tabarena_method_metadata_collection = MethodMetadataCollection(
         # Default tabular models (CPU)
         catboost_new_method_metadata,
         chimeraboost_v030_method_metadata,
+        ctboost_method_metadata,
         ebm_new_method_metadata,
         extra_trees_new_method_metadata,
         knn_metadata,

--- a/packages/tabarena/src/tabarena/models/__init__.py
+++ b/packages/tabarena/src/tabarena/models/__init__.py
@@ -12,6 +12,7 @@ from tabarena.models._registry import (
 if TYPE_CHECKING:
     from tabarena.models._method_metadata import MethodMetadata
     from tabarena.models.chimeraboost.model import ChimeraBoostModel
+    from tabarena.models.ctboost.model import CTBoostModel
     from tabarena.models.exaone_tabular.model import EXAONETabularModel
     from tabarena.models.iltm.model import ILTMModel
     from tabarena.models.knn.model import KNNNewModel
@@ -41,6 +42,7 @@ if TYPE_CHECKING:
 _LAZY_CLASSES: dict[str, str] = {
     "MethodMetadata": "tabarena.models._method_metadata",
     "ChimeraBoostModel": "tabarena.models.chimeraboost.model",
+    "CTBoostModel": "tabarena.models.ctboost.model",
     "EXAONETabularModel": "tabarena.models.exaone_tabular.model",
     "ILTMModel": "tabarena.models.iltm.model",
     "KNNNewModel": "tabarena.models.knn.model",

--- a/packages/tabarena/src/tabarena/models/ctboost/__init__.py
+++ b/packages/tabarena/src/tabarena/models/ctboost/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from tabarena.models.ctboost.hpo import gen_ctboost
+from tabarena.models.ctboost.info import ctboost_info, ctboost_method_metadata
+
+__all__ = ["ctboost_info", "ctboost_method_metadata", "gen_ctboost"]

--- a/packages/tabarena/src/tabarena/models/ctboost/hpo.py
+++ b/packages/tabarena/src/tabarena/models/ctboost/hpo.py
@@ -1,0 +1,170 @@
+"""Frozen TabArena search portfolio for CTBoost."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Sequence
+
+import numpy as np
+
+from tabarena.models.ctboost.model import CTBoostModel
+from tabarena.utils.config_utils import CustomAGConfigGenerator
+
+TABARENA_SEARCH_PORTFOLIO_SIZE = 200
+_SEARCH_PORTFOLIO_SEED = 1234
+_PAIR_BUDGET_PARAM = "tabarena_categorical_pair_budget"
+
+
+def _adaptive_training_budget(learning_rate: float) -> tuple[int, int]:
+    """Return a bounded tree cap and validation patience for a learning rate."""
+    resolved = float(learning_rate)
+    if not math.isfinite(resolved) or resolved <= 0.0:
+        raise ValueError("learning_rate must be finite and positive")
+    iterations = int(round(min(1600.0, max(400.0, 50.0 / resolved)) / 50.0) * 50)
+    patience = round(min(80.0, max(30.0, 0.075 * iterations)))
+    return iterations, patience
+
+
+def _finalize_search_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Resolve internal conditional knobs into valid CTBoost parameters."""
+    resolved = {name: value.item() if isinstance(value, np.generic) else value for name, value in config.items()}
+    leaf_fraction = resolved.pop("__leaf_fraction", None)
+    if leaf_fraction is None:
+        resolved["max_leaves"] = 0
+    else:
+        full_leaf_count = 1 << int(resolved["max_depth"])
+        resolved["max_leaves"] = max(
+            4,
+            min(full_leaf_count - 1, round(float(leaf_fraction) * full_leaf_count)),
+        )
+
+    pair_budget = int(resolved.pop("__categorical_pair_budget", 0))
+    if pair_budget and resolved.get("ordered_ctr", False):
+        resolved[_PAIR_BUDGET_PARAM] = pair_budget
+
+    learning_rate = resolved.get("learning_rate")
+    if learning_rate is not None:
+        iterations, early_stopping_rounds = _adaptive_training_budget(float(learning_rate))
+        resolved.setdefault("iterations", iterations)
+        resolved.setdefault("early_stopping_rounds", early_stopping_rounds)
+    return resolved
+
+
+def _stratified_unit_samples(count: int, dimensions: int) -> np.ndarray:
+    """Create a progressively ordered deterministic Latin-hypercube design."""
+    rng = np.random.default_rng(_SEARCH_PORTFOLIO_SEED)
+    samples = np.empty((count, dimensions), dtype=np.float64)
+    for dimension in range(dimensions):
+        strata = rng.permutation(count)
+        samples[:, dimension] = (strata + rng.random(count)) / count
+
+    remaining = np.ones(count, dtype=bool)
+    minimum_distance = np.sum(np.square(samples - 0.5), axis=1)
+    order: list[int] = []
+    for _ in range(count):
+        candidate_scores = np.where(remaining, minimum_distance, -1.0)
+        selected = int(np.argmax(candidate_scores))
+        order.append(selected)
+        remaining[selected] = False
+        distances = np.sum(np.square(samples - samples[selected]), axis=1)
+        minimum_distance = np.minimum(minimum_distance, distances)
+    return samples[order]
+
+
+def _linear_sample(value: float, lower: float, upper: float) -> float:
+    return float(lower * (1.0 - value) + upper * value)
+
+
+_FROZEN_LOG_SAMPLE_OVERRIDES = {
+    # Windows and glibc libm differ by one ULP for these two frozen design
+    # points. Canonicalize only them so the portfolio hash is cross-platform.
+    (
+        "0x1.4dd35420fef52p-4",
+        "0x1.999999999999ap-4",
+        "0x1.4000000000000p+3",
+    ): float.fromhex("0x1.2a141a19178d4p-3"),
+    (
+        "0x1.61f66383ab081p-1",
+        "0x1.47ae147ae147bp-8",
+        "0x1.0000000000000p-1",
+    ): float.fromhex("0x1.ee4e4f97673a6p-4"),
+}
+
+
+def _log_sample(value: float, lower: float, upper: float) -> float:
+    canonical = _FROZEN_LOG_SAMPLE_OVERRIDES.get((float(value).hex(), float(lower).hex(), float(upper).hex()))
+    if canonical is not None:
+        return canonical
+    return float(math.exp(math.log(lower) * (1.0 - value) + math.log(upper) * value))
+
+
+def _integer_sample(value: float, lower: int, upper: int) -> int:
+    return min(upper, lower + int(value * (upper - lower + 1)))
+
+
+def _log_integer_sample(value: float, lower: int, upper: int) -> int:
+    return min(upper, max(lower, round(_log_sample(value, lower, upper))))
+
+
+def _categorical_sample(value: float, choices: Sequence[Any]) -> Any:
+    return choices[min(len(choices) - 1, int(value * len(choices)))]
+
+
+def generate_configs_ctboost(num_random_configs: int = 200) -> list[dict[str, Any]]:
+    """Generate the frozen, deterministic 200-config CTBoost portfolio."""
+    count = int(num_random_configs)
+    if count < 0:
+        raise ValueError("num_random_configs must be non-negative")
+    if count == 0:
+        return []
+    if count > TABARENA_SEARCH_PORTFOLIO_SIZE:
+        raise ValueError(
+            f"num_random_configs cannot exceed the frozen {TABARENA_SEARCH_PORTFOLIO_SIZE}-config portfolio"
+        )
+
+    samples = _stratified_unit_samples(TABARENA_SEARCH_PORTFOLIO_SIZE, dimensions=17)[:count]
+    configs: list[dict[str, Any]] = []
+    for values in samples:
+        ordered_ctr = bool(values[12] >= 0.25)
+        grow_policy = str(_categorical_sample(values[6], ["DepthWise", "LeafWise"]))
+        config: dict[str, Any] = {
+            "learning_rate": _log_sample(values[0], 2e-2, 2e-1),
+            "max_depth": _integer_sample(values[1], 3, 8),
+            "alpha": _log_sample(values[2], 5e-3, 5e-1),
+            "lambda_l2": _log_sample(values[3], 1e-4, 10.0),
+            "subsample": _linear_sample(values[4], 0.6, 1.0),
+            "colsample_bytree": _linear_sample(values[5], 0.6, 1.0),
+            "grow_policy": grow_policy,
+            "min_data_in_leaf": _log_integer_sample(values[8], 1, 64),
+            "min_child_weight": _categorical_sample(values[9], [0.0, 0.01, 0.1, 1.0, 5.0]),
+            "one_hot_max_size": _categorical_sample(values[10], [2, 4, 16, 64]),
+            "max_cat_threshold": _categorical_sample(values[11], [16, 64, 256]),
+            "ordered_ctr": ordered_ctr,
+            "random_strength": _categorical_sample(values[14], [0.0, 0.01, 0.1, 1.0]),
+            "max_bins": _categorical_sample(values[15], [128, 256]),
+            "bootstrap_type": "Bernoulli",
+        }
+        if grow_policy == "LeafWise":
+            config["__leaf_fraction"] = _categorical_sample(values[7], [0.25, 0.5, 0.75])
+        if ordered_ctr:
+            config["ctr_prior_strength"] = _log_sample(values[13], 0.1, 10.0)
+            config["__categorical_pair_budget"] = _categorical_sample(values[16], [0, 0, 0, 2, 4])
+        configs.append(_finalize_search_config(config))
+    return configs
+
+
+gen_ctboost = CustomAGConfigGenerator(
+    model_cls=CTBoostModel,
+    search_space_func=generate_configs_ctboost,
+    manual_configs=[{}],
+)
+
+
+if __name__ == "__main__":
+    from tabarena.benchmark.experiment import YamlExperimentSerializer
+
+    print(
+        YamlExperimentSerializer.to_yaml_str(
+            experiments=gen_ctboost.generate_all_bag_experiments(num_random_configs=0),
+        )
+    )

--- a/packages/tabarena/src/tabarena/models/ctboost/info.py
+++ b/packages/tabarena/src/tabarena/models/ctboost/info.py
@@ -29,5 +29,5 @@ ctboost_info = ModelInfo(
     model_cls=CTBoostModel,
     search_space=gen_ctboost,
     method_metadata=ctboost_method_metadata,
-    pip_extra=("ctboost>=0.1.56",),
+    pip_extra=("ctboost>=0.1.58",),
 )

--- a/packages/tabarena/src/tabarena/models/ctboost/info.py
+++ b/packages/tabarena/src/tabarena/models/ctboost/info.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from tabarena.models._method_metadata import MethodMetadata
+from tabarena.models._model_info import ModelInfo
+from tabarena.models.ctboost.hpo import gen_ctboost
+from tabarena.models.ctboost.model import CTBoostModel
+
+ctboost_method_metadata = MethodMetadata.config(
+    method="CTBoost",
+    display_name="CTBoost",
+    compute="cpu",
+    date="2026-08-21",
+    date_introduced="2026-04-10",
+    ag_key="CTB",
+    model_key="CTB",
+    config_default="CTBoost_c1_default_BAG_L1",
+    can_hpo=True,
+    is_bag=True,
+    has_raw=True,
+    has_processed=True,
+    has_results=True,
+    suite="tabarena-2026-08-21",
+    verified=False,
+    reference_url="https://github.com/captnmarkus/ctboost",
+)
+
+
+ctboost_info = ModelInfo(
+    model_cls=CTBoostModel,
+    search_space=gen_ctboost,
+    method_metadata=ctboost_method_metadata,
+    pip_extra=("ctboost>=0.1.56",),
+)

--- a/packages/tabarena/src/tabarena/models/ctboost/info.py
+++ b/packages/tabarena/src/tabarena/models/ctboost/info.py
@@ -29,5 +29,5 @@ ctboost_info = ModelInfo(
     model_cls=CTBoostModel,
     search_space=gen_ctboost,
     method_metadata=ctboost_method_metadata,
-    pip_extra=("ctboost>=0.1.60",),
+    pip_extra=("ctboost==0.1.61",),
 )

--- a/packages/tabarena/src/tabarena/models/ctboost/info.py
+++ b/packages/tabarena/src/tabarena/models/ctboost/info.py
@@ -29,5 +29,5 @@ ctboost_info = ModelInfo(
     model_cls=CTBoostModel,
     search_space=gen_ctboost,
     method_metadata=ctboost_method_metadata,
-    pip_extra=("ctboost>=0.1.58",),
+    pip_extra=("ctboost>=0.1.60",),
 )

--- a/packages/tabarena/src/tabarena/models/ctboost/info.py
+++ b/packages/tabarena/src/tabarena/models/ctboost/info.py
@@ -9,7 +9,7 @@ ctboost_method_metadata = MethodMetadata.config(
     method="CTBoost",
     display_name="CTBoost",
     compute="cpu",
-    date="2026-08-21",
+    date="2026-09-09",
     date_introduced="2026-04-10",
     ag_key="CTB",
     model_key="CTB",
@@ -19,8 +19,10 @@ ctboost_method_metadata = MethodMetadata.config(
     has_raw=True,
     has_processed=True,
     has_results=True,
-    suite="tabarena-2026-08-21",
-    verified=False,
+    suite="tabarena-2026-09-09",
+    verified=True,
+    cache_type="r2",
+    cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
     reference_url="https://github.com/captnmarkus/ctboost",
 )
 

--- a/packages/tabarena/src/tabarena/models/ctboost/model.py
+++ b/packages/tabarena/src/tabarena/models/ctboost/model.py
@@ -1,0 +1,386 @@
+"""CTBoost model wrapper for TabArena.
+
+CTBoost is a conditional-inference-tree gradient booster by Markus Maier and
+the CTBoost contributors. The Apache-2.0 implementation is available at
+https://github.com/captnmarkus/ctboost.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import threading
+import time
+from contextlib import contextmanager
+from itertools import combinations
+from typing import Any
+
+import numpy as np
+from autogluon.core.models import AbstractModel
+
+_HISTOGRAM_THREAD_ENV = "CTBOOST_HIST_THREADS"
+_HISTOGRAM_THREAD_LOCK = threading.Lock()
+_MIN_TRAINING_BUDGET_FRACTION = 0.4
+_TRAINING_TIME_LIMIT_FRACTION = 0.95
+_PAIR_BUDGET_PARAM = "tabarena_categorical_pair_budget"
+_PAIR_BUDGET_LIMIT = 4
+_PAIR_CANDIDATE_COLUMN_LIMIT = 16
+_PAIR_JOINT_CARDINALITY_LIMIT = 4096
+
+
+def _stopping_metric_name(metric: Any) -> str | None:
+    """Return AutoGluon's scorer name in a comparison-friendly form."""
+    if metric is None:
+        return None
+    name = getattr(metric, "name", None)
+    if callable(name):
+        try:
+            name = name()
+        except TypeError:
+            name = None
+    if not isinstance(name, str):
+        if isinstance(metric, str):
+            name = metric
+        else:
+            name = getattr(metric, "__name__", None)
+    if not isinstance(name, str) or not name.strip():
+        return None
+    return name.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _ctboost_eval_metric(problem_type: Any, stopping_metric: Any) -> str | None:
+    """Translate supported AutoGluon stopping scorers to CTBoost metrics."""
+    resolved_problem_type = str(problem_type).strip().lower()
+    resolved_metric = _stopping_metric_name(stopping_metric)
+    mappings = {
+        "binary": {"roc_auc": "AUC", "log_loss": "Logloss"},
+        "multiclass": {"log_loss": "MultiClass"},
+        "regression": {
+            "rmse": "RMSE",
+            "root_mean_squared_error": "RMSE",
+        },
+    }
+    return mappings.get(resolved_problem_type, {}).get(resolved_metric)
+
+
+def _resolve_time_limit(time_limit: float | None) -> float | None:
+    if time_limit is None:
+        return None
+    resolved = float(time_limit)
+    if not math.isfinite(resolved) or resolved <= 0.0:
+        raise ValueError("time_limit must be finite and positive when provided")
+    return resolved
+
+
+def _callback_list(callbacks: Any) -> list[Any]:
+    if callbacks is None:
+        return []
+    if callable(callbacks):
+        return [callbacks]
+    try:
+        return list(callbacks)
+    except TypeError as exc:
+        raise TypeError("callbacks must be callable or an iterable of callables") from exc
+
+
+def _raise_time_limit_exceeded() -> None:
+    from autogluon.core.utils.exceptions import TimeLimitExceeded
+
+    raise TimeLimitExceeded("Insufficient AutoGluon fit budget remains after CTBoost adapter setup")
+
+
+def _deadline_callback(deadline: float, training_started_at: float) -> Any:
+    """Stop when the budget cannot safely fit two average tree iterations."""
+
+    def _stop_at_deadline(env: Any) -> bool:
+        now = time.monotonic()
+        if now >= deadline:
+            return True
+        completed_iterations = max(1, int(env.iteration) - int(env.begin_iteration) + 1)
+        average_iteration_time = max(0.0, (now - training_started_at) / completed_iterations)
+        return now + 2.0 * average_iteration_time >= deadline
+
+    return _stop_at_deadline
+
+
+@contextmanager
+def _ctboost_histogram_threads(num_cpus: Any):
+    """Keep native histogram workers inside TabArena's per-fit CPU budget."""
+    resolved = 1 if num_cpus is None else max(1, int(num_cpus))
+    with _HISTOGRAM_THREAD_LOCK:
+        previous = os.environ.get(_HISTOGRAM_THREAD_ENV)
+        os.environ[_HISTOGRAM_THREAD_ENV] = str(resolved)
+        try:
+            yield
+        finally:
+            if previous is None:
+                os.environ.pop(_HISTOGRAM_THREAD_ENV, None)
+            else:
+                os.environ[_HISTOGRAM_THREAD_ENV] = previous
+
+
+def _categorical_columns(frame: Any) -> list[str]:
+    """Return columns that should use CTBoost's native categorical pipeline."""
+    columns: list[str] = []
+    for name, dtype in frame.dtypes.items():
+        dtype_name = str(dtype).lower()
+        if dtype_name in {"object", "category", "string"} or dtype_name.startswith("string["):
+            columns.append(str(name))
+    return columns
+
+
+def _resolve_categorical_pair_budget(value: Any) -> int:
+    """Validate the small adapter-only categorical-pair budget."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{_PAIR_BUDGET_PARAM} must be an integer")
+    resolved = int(value)
+    if not 0 <= resolved <= _PAIR_BUDGET_LIMIT:
+        raise ValueError(f"{_PAIR_BUDGET_PARAM} must be between 0 and {_PAIR_BUDGET_LIMIT}")
+    return resolved
+
+
+def normalize_tabarena_frame(
+    frame: Any,
+    *,
+    categorical_columns: list[str] | tuple[str, ...] | None = None,
+) -> tuple[Any, list[str]]:
+    """Preserve native categorical, missing, boolean, and unseen-value semantics."""
+    import pandas as pd
+
+    if not isinstance(frame, pd.DataFrame):
+        frame = pd.DataFrame(frame)
+    normalized_columns = [str(name) for name in frame.columns]
+    if list(frame.columns) == normalized_columns:
+        normalized = frame
+    else:
+        normalized = frame.copy(deep=False)
+        normalized.columns = normalized_columns
+
+    resolved_categoricals = (
+        _categorical_columns(normalized) if categorical_columns is None else [str(name) for name in categorical_columns]
+    )
+    missing_columns = [name for name in resolved_categoricals if name not in normalized.columns]
+    if missing_columns:
+        raise ValueError(
+            "TabArena prediction data is missing categorical columns seen during fit: " + ", ".join(missing_columns)
+        )
+    return normalized, resolved_categoricals
+
+
+def _bounded_categorical_pairs(
+    frame: Any,
+    categorical_columns: list[str],
+    *,
+    max_pairs: int,
+    max_joint_cardinality: int = _PAIR_JOINT_CARDINALITY_LIMIT,
+) -> list[list[str]]:
+    """Select a deterministic set of inexpensive categorical pairs from training data."""
+    budget = max(0, int(max_pairs))
+    if budget == 0 or len(categorical_columns) < 2:
+        return []
+
+    column_order = {name: index for index, name in enumerate(categorical_columns)}
+    cardinalities: list[tuple[int, int, str]] = []
+    for name in categorical_columns:
+        cardinality = int(frame[name].nunique(dropna=False))
+        if 1 < cardinality <= max_joint_cardinality:
+            cardinalities.append((cardinality, column_order[name], name))
+
+    cardinalities.sort()
+    candidates = cardinalities[:_PAIR_CANDIDATE_COLUMN_LIMIT]
+    ranked_pairs: list[tuple[int, int, int, str, str]] = []
+    for left, right in combinations(candidates, 2):
+        joint_upper_bound = left[0] * right[0]
+        if joint_upper_bound <= max_joint_cardinality:
+            left_order, right_order = sorted((left[1], right[1]))
+            left_name = categorical_columns[left_order]
+            right_name = categorical_columns[right_order]
+            ranked_pairs.append((joint_upper_bound, left_order, right_order, left_name, right_name))
+
+    ranked_pairs.sort()
+    return [[left, right] for _, _, _, left, right in ranked_pairs[:budget]]
+
+
+class CTBoostModel(AbstractModel):
+    """AutoGluon wrapper for CTBoost's classifier and regressor estimators."""
+
+    ag_key = "CTB"
+    ag_name = "CTBoost"
+    ag_priority = 65
+    seed_name = "random_seed"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
+    _default_auxiliary_params_extra = {
+        "valid_raw_types": ["bool", "int", "float", "category", "object"],
+        "ignored_type_group_special": ["datetime_as_object"],
+    }
+    default_resources_physical_cores_only = True
+    default_num_gpus = 0
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._ctboost_categorical_columns: list[str] = []
+
+    def _preprocess(self, X: Any, is_train: bool = False, **kwargs: Any) -> Any:
+        X = super()._preprocess(X, **kwargs)
+        categorical_columns = None if is_train else self._ctboost_categorical_columns
+        X, resolved = normalize_tabarena_frame(X, categorical_columns=categorical_columns)
+        if is_train:
+            self._ctboost_categorical_columns = resolved
+        return X
+
+    def _fit(
+        self,
+        X: Any,
+        y: Any,
+        X_val: Any = None,
+        y_val: Any = None,
+        sample_weight: Any = None,
+        num_cpus: int = 1,
+        num_gpus: float = 0,
+        time_limit: float | None = None,
+        callbacks: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        del num_gpus, kwargs
+        resolved_time_limit = _resolve_time_limit(time_limit)
+        training_deadline = None
+        if resolved_time_limit is not None:
+            fit_started_at = time.monotonic()
+            training_deadline = fit_started_at + resolved_time_limit * _TRAINING_TIME_LIMIT_FRACTION
+
+        from ctboost import CTBoostClassifier, CTBoostRegressor
+
+        X_train = self.preprocess(X, y=y, is_train=True)
+        X_validation = None
+        if X_val is not None:
+            X_validation = self.preprocess(X_val, is_train=False)
+
+        params = dict(self._get_model_params())
+        early_stopping_rounds = int(params.pop("early_stopping_rounds", 50))
+        categorical_pair_budget = _resolve_categorical_pair_budget(params.pop(_PAIR_BUDGET_PARAM, 0))
+        configured_callbacks = _callback_list(params.pop("callbacks", None))
+        configured_callbacks.extend(_callback_list(callbacks))
+        if "eval_metric" not in params:
+            eval_metric = _ctboost_eval_metric(self.problem_type, getattr(self, "stopping_metric", None))
+            if eval_metric is not None:
+                params["eval_metric"] = eval_metric
+        params["cat_features"] = self._ctboost_categorical_columns or None
+        if (
+            categorical_pair_budget
+            and "categorical_combinations" not in params
+            and not params.get("pairwise_categorical_combinations", False)
+        ):
+            categorical_pairs = _bounded_categorical_pairs(
+                X_train,
+                self._ctboost_categorical_columns,
+                max_pairs=categorical_pair_budget,
+            )
+            if categorical_pairs:
+                params["categorical_combinations"] = categorical_pairs
+        params["task_type"] = "CPU"
+
+        if self.problem_type == "regression":
+            self.model = CTBoostRegressor(**params)
+        else:
+            self.model = CTBoostClassifier(**params)
+
+        fit_kwargs: dict[str, Any] = {"sample_weight": sample_weight}
+        if X_validation is not None and y_val is not None:
+            fit_kwargs.update(
+                {
+                    "eval_set": (X_validation, np.asarray(y_val)),
+                    "early_stopping_rounds": early_stopping_rounds,
+                }
+            )
+        with _ctboost_histogram_threads(num_cpus):
+            if training_deadline is not None:
+                training_started_at = time.monotonic()
+                remaining_time = training_deadline - training_started_at
+                if remaining_time <= resolved_time_limit * _MIN_TRAINING_BUDGET_FRACTION:
+                    _raise_time_limit_exceeded()
+                configured_callbacks.append(_deadline_callback(training_deadline, training_started_at))
+            if configured_callbacks:
+                fit_kwargs["callbacks"] = configured_callbacks
+            self.model.fit(X_train, np.asarray(y), **fit_kwargs)
+        best_iteration = self.model.get_best_iteration()
+        if best_iteration is not None and int(best_iteration) >= 0:
+            self.params_trained["iterations"] = int(best_iteration) + 1
+
+    def _set_default_params(self) -> None:
+        defaults = {
+            "iterations": 1000,
+            "learning_rate": 0.05,
+            "max_depth": 6,
+            "alpha": 0.05,
+            "lambda_l2": 1.0,
+            "subsample": 0.8,
+            "bootstrap_type": "Bernoulli",
+            "ordered_ctr": True,
+            "max_cat_threshold": 64,
+            "early_stopping_rounds": 50,
+            "verbose": False,
+        }
+        for name, value in defaults.items():
+            self._set_default_param_value(name, value)
+
+    @classmethod
+    def _estimate_memory_usage_static(
+        cls,
+        *,
+        X: Any,
+        hyperparameters: dict[str, Any] | None = None,
+        num_classes: int | None = 1,
+        **kwargs: Any,
+    ) -> int:
+        """Conservatively estimate peak fit memory for fold scheduling."""
+        del kwargs
+        params = dict(hyperparameters or {})
+        rows, raw_columns = (int(value) for value in X.shape)
+        classes = max(1, int(num_classes or 1))
+        try:
+            from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
+
+            input_bytes = int(get_approximate_df_mem_usage(X).sum())
+        except (ImportError, AttributeError, TypeError):
+            memory_usage = getattr(X, "memory_usage", None)
+            input_bytes = (
+                int(memory_usage(index=True, deep=True).sum()) if callable(memory_usage) else rows * raw_columns * 8
+            )
+
+        categorical_columns = _categorical_columns(X)
+        categorical_count = len(categorical_columns)
+        one_hot_max_size = max(0, int(params.get("one_hot_max_size", 0)))
+        max_cat_threshold = max(0, int(params.get("max_cat_threshold", 64)))
+        ordered_ctr = bool(params.get("ordered_ctr", True))
+        transformed_columns = raw_columns - categorical_count
+        for name in categorical_columns:
+            # CTBoost either one-hot expands a low-cardinality source or keeps
+            # one encoded source plus one ordered-CTR column per class.
+            cardinality = max(1, int(X[name].nunique(dropna=False)))
+            if max_cat_threshold > 1:
+                cardinality = min(cardinality, max_cat_threshold)
+            if 0 < cardinality <= one_hot_max_size:
+                transformed_columns += cardinality
+            else:
+                transformed_columns += 1 + (classes if ordered_ctr else 0)
+
+        pair_budget = _resolve_categorical_pair_budget(params.get(_PAIR_BUDGET_PARAM, 0))
+        transformed_columns += min(pair_budget, _PAIR_BUDGET_LIMIT) * (1 + (classes if ordered_ctr else 0))
+        columns = max(raw_columns, transformed_columns)
+        max_bins = max(1, int(params.get("max_bins", 256)))
+        bin_width = 1 if max_bins <= 256 else 2 if max_bins <= 65_535 else 4
+        quantized_bytes = rows * columns * bin_width
+        statistic_bytes = rows * classes * 8 * 6
+        histogram_bytes = columns * max_bins * classes * 8 * 3
+
+        depth = max(0, int(params.get("max_depth", params.get("depth", 6))))
+        depth_leaves = 1 << min(depth, 20)
+        configured_leaves = int(params.get("max_leaves", 0) or 0)
+        leaves = min(depth_leaves, configured_leaves) if configured_leaves > 0 else depth_leaves
+        iterations = max(1, int(params.get("iterations", params.get("n_estimators", 1000))))
+        tree_bytes = iterations * classes * max(1, 2 * leaves - 1) * 64
+
+        baseline_bytes = 512 * 1024 * 1024
+        return int(
+            baseline_bytes + 4 * input_bytes + 2 * quantized_bytes + statistic_bytes + histogram_bytes + tree_bytes
+        )

--- a/packages/tabarena/src/tabarena/website/website_format.py
+++ b/packages/tabarena/src/tabarena/website/website_format.py
@@ -137,6 +137,7 @@ def get_model_family(model_name: str, system_names: Container[str] = frozenset()
             "PB",
             "PERPETUALBOOSTER",
             "CHIMERA",
+            "CTB",
         ],
         Constants.foundational: [
             "TABDPT",
@@ -202,6 +203,7 @@ def get_rename_map() -> dict[str, str]:
         "RF": "RandomForest",
         "PB": "PerpetualBooster",
         "CHIMERA": "ChimeraBoost",
+        "CTB": "CTBoost",
         "MNCA": "ModernNCA",
         "NN_TORCH": "TorchMLP",
         "FASTAI": "FastaiMLP",

--- a/packages/tabflow_slurm/BENCHMARK_LOG.md
+++ b/packages/tabflow_slurm/BENCHMARK_LOG.md
@@ -33,6 +33,58 @@ run against `main`. To reproduce an entry, check out its recorded **git SHA**.
 
 ---
 
+## 2026-09-09 — ctboost_09092026
+
+- **Model(s):** CTBoost (all configs)
+- **Git SHA:** `682365c1`
+- **Purpose:** First full TabArena-v0.1 run of CTBoost (conditional-inference-tree gradient
+  booster, https://github.com/captnmarkus/ctboost) for its integration in
+  https://github.com/autogluon/tabarena/pull/479, pinned to `ctboost==0.1.61`. Processed and
+  uploaded as suite `tabarena-2026-09-09` (`ctboost_method_metadata`), registered in the arena
+  collection as a verified model.
+- **Notes:** Same shape as the CPU tree boosters (ChimeraBoost, Perpetual): full task set (all
+  splits), default config + the full 200-config HPO space, CPU partition `cpun416mtspotinteractive`
+  (16 vCPUs, 64 GB RAM), `memory_limit`/`num_cpus` left `None` so node values are picked up, bundle
+  size 2. Extra dep in the run venv: `ctboost==0.1.61`. CPU model, so no `fake_memory_for_estimates`;
+  `CTBoostModel._estimate_memory_usage_static` is compared against node RAM to budget the parallel
+  bagging folds. No untimed warm-up hook (`CTBoostModel` has no `warmup` classmethod), so any
+  first-call cost of the library lands inside the first timed fit of each worker. The wrapper caps
+  the native histogram threads through `CTBOOST_HIST_THREADS`, which the `.so` reads per fit, so the
+  cap holds in Ray fold workers. Supersedes the lite / 25-config run `ctboost_08092026` on 0.1.60
+  (2026-09-08, job 1100344), which was never uploaded. About 26 h of cluster time (2026-09-09 13:42
+  to 2026-09-10 16:01); 164,016 result files (816 splits x 201 configs).
+
+```python
+from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
+from tabarena.benchmark.task.metadata import TaskSubset
+from tabflow_slurm import (
+    GCPSlurmSetup,
+    ModelJob,
+    PathSetup,
+    TabArenaV0pt1BenchmarkPlan,
+    TabArenaV0pt1ResourcesSetup,
+)
+
+plan = TabArenaV0pt1BenchmarkPlan(
+    benchmark_name="ctboost_09092026",
+    model_jobs=[
+        ModelJob(models=("CTBoost", "all"), name="cpu"),
+    ],
+    task_subset=TaskSubset(),  # all splits of every task
+    path_setup=PathSetup(
+        workspace="/home/lennart_priorlabs_ai/workspace/benchmarking/tabarena_workspace",
+        python_path="/home/lennart_priorlabs_ai/.venvs/tabarena_10082026/bin/python",
+    ),
+    experiment_bundle=TabArenaV0pt1ExperimentBundle(model_verbosity=2),
+    resources_setup=TabArenaV0pt1ResourcesSetup(num_cpus=None, memory_limit=None),
+    # Same CPU partition as the ChimeraBoost runs (16 vCPUs, 64 GB RAM) for comparable timings.
+    scheduler_setup=GCPSlurmSetup(bundle_size=2, cpu_partition="cpun416mtspotinteractive"),
+)
+plan.setup_jobs()
+```
+
+---
+
 ## 2026-08-10 — chimeraboost_10082026
 
 - **Model(s):** ChimeraBoost (all configs)

--- a/tests/tabarena/models/smoke_configs.py
+++ b/tests/tabarena/models/smoke_configs.py
@@ -39,6 +39,7 @@ class ModelSmokeTest:
 SMOKE_OVERRIDES: dict[str, ModelSmokeTest] = {
     "PerpetualBooster": ModelSmokeTest({"iteration_limit": 10, "budget": 0.1}),
     "ChimeraBoost": ModelSmokeTest({"n_estimators": 100}),
+    "CTBoost": ModelSmokeTest({"iterations": 10, "early_stopping_rounds": 3}),
     "ModernNCA": ModelSmokeTest({"n_epochs": 10}),
     "ModernNCA_GPU": ModelSmokeTest({"n_epochs": 10}),
     "RealMLP": ModelSmokeTest({"n_epochs": 10}),


### PR DESCRIPTION
## Summary

Adds CTBoost 0.1.61 for CPU classification and regression, with native categorical handling, missing values, validation early stopping and per-fit resource limits. Both installation paths pin the published `ctboost==0.1.61` release, which includes inference optimizations and correctness fixes.

<details>
<summary>Details</summary>

The conditional-inference learner, defaults and deterministic 200-configuration search portfolio are preserved. Rebased onto current main; the persistence tests match upstream.

Local checks measured 1.79x faster warm prediction across 14 saved models with identical predictions. This is not a new TabArena score; [measurement protocol and limitations](https://github.com/captnmarkus/ctboost/tree/833a775/benchmarks/results/release_readiness_20260908/inference_timing_phase3).

</details>

## Tests

27 selected tests passed with the public 0.1.61 wheel, including binary, multiclass and regression fits:

- `pytest tests/tabarena/benchmark/experiment/test_persist_inference.py tests/tabarena/models/test_registry.py tests/tabarena/models/test_lazy_imports.py -q`
- `pytest -m models -k CTBoost tests/tabarena/models/test_all_models.py -q`
- `ruff check .` and `ruff format --check .` passed with Ruff 0.14.0.

## Model or system submission

Kind: model; binary classification, multiclass classification and regression. Apache-2.0; public PyPI wheels, no credentials required.

- [x] Model files, registry, extra, website family and shared smoke configuration included.
- [x] Validation data, resource limits and seeds supported; 200 HPO configurations; exact dependency pin.
- [x] Selected tests, model smoke and repository lint/format checks passed.
- [ ] Lite default plus 25 HPO results for **0.1.61**; pending. [Lennart's prior-release Lite results](https://github.com/autogluon/tabarena/pull/479#issuecomment-5588951890) remain separate.
- Author sign-off: @captnmarkus.

[Source](https://github.com/captnmarkus/ctboost) | [Release](https://github.com/captnmarkus/ctboost/releases/tag/v0.1.61) | [Documentation](https://captnmarkus.github.io/ctboost/)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
