### PR TITLE
Add Hard Voting, Median Ensembler and a new NoPreprocessingTaskEvaluator for them

### DIFF
--- a/packages/tabarena/src/tabarena/simulation/ensemble/__init__.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/__init__.py
@@ -11,6 +11,8 @@ from tabarena.simulation.ensemble.autogluon_stacker import (
 )
 from tabarena.simulation.ensemble.basic_ensemblers import (
     FixedWeightsEnsembler,
+    HardVotingEnsembler,
+    MedianEnsembler,
     SingleBestEnsembler,
     TopKAverageEnsembler,
 )
@@ -24,8 +26,10 @@ __all__ = [
     "AutoGluonStackerRegressor",
     "FixedWeightsEnsembler",
     "GreedyEnsembler",
+    "HardVotingEnsembler",
     "HillClimbingEnsembler",
     "LegacyEnsemblerAdapter",
+    "MedianEnsembler",
     "SingleBestEnsembler",
     "StackingEnsembler",
     "TopKAverageEnsembler",

--- a/packages/tabarena/src/tabarena/simulation/ensemble/basic_ensemblers.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/basic_ensemblers.py
@@ -8,11 +8,11 @@ or ``repo.evaluate_ensemble(ensemble_kwargs={"ensembler_cls": ..., "ensembler_kw
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 import numpy as np
 
-from tabarena.simulation.ensemble.abstract_ensembler import WeightedEnsembler
+from tabarena.simulation.ensemble.abstract_ensembler import AbstractEnsembler, WeightedEnsembler
 
 if TYPE_CHECKING:
     from autogluon.core.metrics import Scorer
@@ -71,3 +71,62 @@ class FixedWeightsEnsembler(WeightedEnsembler):
     def _fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> None:
         if len(self.weights_) != len(predictions):
             raise ValueError(f"FixedWeightsEnsembler got {len(self.weights_)} weights for {len(predictions)} models")
+
+
+class MedianEnsembler(AbstractEnsembler):
+    """Applies the median for every prediction; nothing is fitted.
+
+    The medians are normalized to produce probabilities in the multiclass case.
+    """
+
+    @override
+    def _fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> None:
+        if predictions.ndim < 3 and self.problem_type == "multiclass":
+            raise ValueError(
+                f"{self.__class__.__name__} has predictions with only {predictions.ndim} dimensions when there should be 3 for multiclass classification, to allow normalization. It is likely wrong classes were wrongly extracted before predicting."
+            )
+
+    @override
+    def predict_proba(self, predictions: np.ndarray) -> np.ndarray:
+        median_predictions = np.median(predictions, axis=0)
+        if self.problem_type in ["binary", "regression"]:
+            # Normalization unnecessary for binary as the other class median corresponds to the same sample.
+            return median_predictions
+        if predictions.ndim != 3:
+            raise ValueError(
+                f"Expected predictions with 3 dimensions (n_models, n_samples, n_classes) in the multiclass case, got {predictions.ndim} dimensions."
+            )
+        # Normalization for multiclass
+        return median_predictions / median_predictions.sum(axis=1, keepdims=True)
+
+
+class HardVotingEnsembler(AbstractEnsembler):
+    """Applies a vote between different classifiers; nothing is fitted.
+
+    It only works with classification, not regression. Class probabilities are estimated through the probability that a base learner would vote for a class.
+    """
+
+    def __init__(self, *, problem_type: str, metric: Scorer):
+        if problem_type not in ["binary", "multiclass"]:
+            raise ValueError(
+                f"{self.__class__.__name__} only works with classification problems, not with {problem_type}."
+            )
+        super().__init__(problem_type=problem_type, metric=metric)
+
+    @override
+    def _fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> None:
+        if predictions.ndim < 3 and self.problem_type == "multiclass":
+            raise ValueError(
+                f"{self.__class__.__name__} has predictions with only {predictions.ndim} dimensions when there should be 3 for multiclass classification, to allow a vote. It is likely wrong classes were wrongly extracted before predicting."
+            )
+
+    @override
+    def predict_proba(self, predictions: np.ndarray) -> np.ndarray:
+        if self.problem_type == "binary":
+            return ((predictions > 0.5) + 0.5 * (predictions == 0.5)).mean(axis=0)
+        # Binary matrix with 1 for the highest predicted probability, 0 otherwise.
+        is_max = predictions == np.max(predictions, axis=2, keepdims=True)
+        # For equalities, the vote is divided among all concerned classes.
+        is_max = (is_max / is_max.sum(axis=2, keepdims=True)).astype(np.float32)
+        # Proportion of vote used as probability estimation.
+        return is_max.mean(axis=0)

--- a/packages/tabarena/src/tabarena/simulation/ensemble_selection_config_scorer.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble_selection_config_scorer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import os
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 import numpy as np
 from autogluon.core.metrics import Scorer, get_metric
@@ -214,6 +214,46 @@ class TaskEvaluator:
             results["ensemble_info"] = ensemble_info
 
         return results, ensemble
+
+
+class NoPreprocessingTaskEvaluator(TaskEvaluator):
+    """Minimal per-task evaluator that only uses the metric's `preprocess_bulk` when computing the metric, not before training and predicting.
+
+    Needed for ensemble methods which use multiple class predictions and fast metrics.
+
+    Due to the lack of preprocessing at first and a final processing, there is a difference of around 1e-6 in the log_loss with TaskEvaluator.
+    """
+
+    @override
+    def fit(self, *, pred_train: np.ndarray, y_train: np.ndarray) -> AbstractEnsembler:
+        ensemble = self.init_ens()
+        ensemble.fit(predictions=pred_train, labels=y_train)
+        return ensemble
+
+    @override
+    def predict(
+        self, *, ensemble: AbstractEnsembler, pred: np.ndarray, y: np.ndarray, eval_metric: Scorer | None = None
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if eval_metric is None:
+            eval_metric = self._eval_metric
+
+        pred = pred.astype(np.float64)
+
+        if eval_metric.needs_pred:
+            # Label-space predictions are for the original problem, not the (possibly
+            # metric-preprocessed) problem type the ensembler was fitted on.
+            y_pred = ensemble.predict(pred, problem_type=self.problem_type)
+        else:
+            y_pred = ensemble.predict_proba(pred)
+        return y_pred, y
+
+    @override
+    def error(self, *, y: np.ndarray, y_pred: np.ndarray, eval_metric: Scorer | None = None) -> float:
+        if eval_metric is None:
+            eval_metric = self._eval_metric
+        y, y_pred = self._maybe_preprocess_bulk(eval_metric, y, np.expand_dims(y_pred, axis=0))
+        y_pred = y_pred.astype(np.float64)
+        return eval_metric.error(y, y_pred)
 
 
 class EnsembleScorer:

--- a/tests/tabarena/simulation/test_ensembler.py
+++ b/tests/tabarena/simulation/test_ensembler.py
@@ -195,7 +195,7 @@ def test_task_evaluator_new_interface_matches_legacy(metric_name):
     assert results_legacy["metric_error_val"] == results_new["metric_error_val"]
     np.testing.assert_array_equal(results_legacy["ensemble_weights"], results_new["ensemble_weights"])
     np.testing.assert_array_equal(results_legacy["ensemble_models_used"], results_new["ensemble_models_used"])
-    np.testing.assert_array_equal(results_new["ensemble_models_used"], results_new["ensemble_weights"] != 0)
+    np.testing.assert_array_equal(results_legacy["ensemble_models_used"], results_new["ensemble_weights"] != 0)
 
 
 def test_resolve_ensembler_drops_ensemble_size_for_unsupported_cls():
@@ -229,6 +229,70 @@ def test_resolve_ensembler_drops_ensemble_size_for_unsupported_cls():
     )
     assert cls is GreedyEnsembler
     assert kwargs == {"ensemble_size": 40}
+
+
+def _run_no_preprocessing_task_evaluator(
+    ensembler_cls, ensembler_kwargs, *, problem_type, eval_metric, fit_eval_metric, y, preds
+):
+    from tabarena.simulation.ensemble_selection_config_scorer import NoPreprocessingTaskEvaluator
+
+    evaluator = NoPreprocessingTaskEvaluator(
+        ensembler_cls=ensembler_cls,
+        ensembler_kwargs=ensembler_kwargs,
+        eval_metric=eval_metric,
+        fit_eval_metric=fit_eval_metric,
+        problem_type=problem_type,
+    )
+    results, ensemble = evaluator.run(
+        pred_train=preds,
+        y_train=y,
+        pred_test=preds,
+        y_test=y,
+        return_metric_error_val=True,
+        pred_val=preds,
+        y_val=y,
+    )
+    return results, ensemble
+
+
+@pytest.mark.parametrize("metric_name", ["roc_auc", "log_loss", "rmse"])
+def test_no_preprocessing_task_evaluator_matches_task_evaluator(metric_name):
+    """NoPreprocessingTaskEvaluator with a non EnsembleSelection method must match TaskEvaluator across all three metric regimes (incl. the metric-preprocessed log_loss space and the needs_pred rmse path)."""
+    from tabarena.simulation.ensemble import TopKAverageEnsembler
+
+    problem_type, metric, y, preds = _task_for_metric(metric_name)
+
+    ensembler_cls = TopKAverageEnsembler
+    ensembler_kwargs = {}
+
+    results, _ = _run_task_evaluator(
+        ensembler_cls,
+        ensembler_kwargs,
+        problem_type=problem_type,
+        eval_metric=metric,
+        fit_eval_metric=metric,
+        y=y,
+        preds=preds,
+    )
+    results_no_preprocessing, _ = _run_no_preprocessing_task_evaluator(
+        ensembler_cls,
+        ensembler_kwargs,
+        problem_type=problem_type,
+        eval_metric=metric,
+        fit_eval_metric=metric,
+        y=y,
+        preds=preds,
+    )
+
+    if metric_name == "log_loss":
+        assert pytest.approx(results["metric_error"], 1e-6) == results_no_preprocessing["metric_error"]
+        assert pytest.approx(results["metric_error_val"], 1e-6) == results_no_preprocessing["metric_error_val"]
+    else:
+        assert results["metric_error"] == results_no_preprocessing["metric_error"]
+        assert results["metric_error_val"] == results_no_preprocessing["metric_error_val"]
+    np.testing.assert_array_equal(results["ensemble_weights"], results_no_preprocessing["ensemble_weights"])
+    np.testing.assert_array_equal(results["ensemble_models_used"], results_no_preprocessing["ensemble_models_used"])
+    np.testing.assert_array_equal(results["ensemble_models_used"], results_no_preprocessing["ensemble_weights"] != 0)
 
 
 # -------------------------
@@ -358,6 +422,214 @@ def test_nonlinear_ensembler_rejected_on_preprocessed_metric_space():
     assert np.isfinite(results["metric_error"])
     assert "ensemble_weights" not in results  # not weight-based
     assert results["ensemble_models_used"].all()  # conservative default: all models used
+
+
+@pytest.mark.parametrize("problem_type", ["binary", "multiclass", "regression"])
+def test_median_ensembler_basic(problem_type):
+    from tabarena.simulation.ensemble import MedianEnsembler
+
+    if problem_type == "binary":
+        y, preds = _make_binary_task(seed=7)
+        metric = get_metric(metric="roc_auc", problem_type=problem_type)
+    elif problem_type == "multiclass":
+        y, preds = _make_multiclass_task(seed=7)
+        metric = get_metric(metric="log_loss", problem_type=problem_type)
+    else:
+        y, preds = _make_regression_task(seed=7)
+        metric = get_metric(metric="rmse", problem_type=problem_type)
+
+    ensembler = MedianEnsembler(problem_type=problem_type, metric=metric)
+    ensembler.fit(predictions=preds, labels=y)
+
+    # new data (a copy) uses the full refit model
+    out = ensembler.predict_proba(preds.copy())
+    if problem_type == "multiclass":
+        assert out.shape == (len(y), preds.shape[2])
+        np.testing.assert_allclose(out.sum(axis=1), 1.0, rtol=1e-6)
+    else:
+        assert out.shape == (len(y),)
+    if problem_type in ["binary", "multiclass"]:
+        assert np.all(out <= 1.0)
+        assert np.all(out >= 0.0)
+    assert ensembler.model_weights() is None
+
+
+@pytest.mark.parametrize("problem_type", ["binary", "multiclass", "regression"])
+def test_median_predictions(problem_type):
+    from tabarena.simulation.ensemble import MedianEnsembler
+
+    if problem_type == "binary":
+        preds = np.array(
+            [
+                [0.2, 0.7, 0.8, 0.7],
+                [0.4, 0.6, 0.5, 0.4],
+                [0.3, 0.6, 0.6, 0.4],
+            ],
+            dtype=np.float32,
+        )
+        expected_proba = np.array(
+            [0.3, 0.6, 0.6, 0.4],
+            dtype=np.float32,
+        )
+        expected_classes = np.array([0, 1, 1, 0])
+        metric = get_metric(metric="roc_auc", problem_type=problem_type)
+    elif problem_type == "multiclass":
+        preds = np.array(
+            [
+                [
+                    [0.0, 0.1, 0.9],
+                    [0.2, 0.5, 0.3],
+                    [0.6, 0.1, 0.3],
+                ],
+                [
+                    [0.2, 0.4, 0.4],
+                    [0.2, 0.5, 0.3],
+                    [0.2, 0.7, 0.1],
+                ],
+                [
+                    [0.1, 0.1, 0.8],
+                    [0.2, 0.6, 0.2],
+                    [0.5, 0.4, 0.1],
+                ],
+            ],
+            dtype=np.float32,
+        )
+        expected_proba = np.array(
+            [
+                [0.1, 0.1, 0.8],
+                [0.2, 0.5, 0.3],
+                [0.5, 0.4, 0.1],
+            ],
+            dtype=np.float32,
+        )
+        expected_classes = np.array([2, 1, 0])
+        metric = get_metric(metric="log_loss", problem_type=problem_type)
+    elif problem_type == "regression":
+        preds = np.array(
+            [
+                [10, 30, 10],
+                [20, 20, 30],
+                [30, 20, 30],
+            ],
+            dtype=np.float32,
+        )
+        expected_proba = np.array([20, 20, 30], dtype=np.float32)
+        metric = get_metric("rmse", problem_type=problem_type)
+
+    ensembler = MedianEnsembler(problem_type=problem_type, metric=metric)
+
+    out_proba = ensembler.predict_proba(preds.copy())
+    out_classes = ensembler.predict(preds.copy())
+    np.testing.assert_allclose(out_proba, expected_proba, rtol=1e-6)
+    if problem_type in ["binary", "multiclass"]:
+        assert np.all(out_classes == expected_classes)
+
+
+@pytest.mark.parametrize("problem_type", ["binary", "multiclass"])
+def test_hard_voting_ensembler_basic(problem_type):
+    from tabarena.simulation.ensemble import HardVotingEnsembler
+
+    if problem_type == "binary":
+        y, preds = _make_binary_task(seed=7)
+        metric = get_metric(metric="roc_auc", problem_type=problem_type)
+    else:
+        y, preds = _make_multiclass_task(seed=7)
+        metric = get_metric(metric="log_loss", problem_type=problem_type)
+
+    ensembler = HardVotingEnsembler(problem_type=problem_type, metric=metric)
+    ensembler.fit(predictions=preds, labels=y)
+
+    out = ensembler.predict_proba(preds.copy())
+    if problem_type == "multiclass":
+        assert out.shape == (len(y), preds.shape[2])
+        np.testing.assert_allclose(out.sum(axis=1), 1.0, rtol=1e-6)
+    else:
+        assert out.shape == (len(y),)
+    assert np.all(out <= 1.0)
+    assert np.all(out >= 0.0)
+    assert ensembler.model_weights() is None
+
+
+def test_hard_voting_fails_regression():
+    from tabarena.simulation.ensemble import HardVotingEnsembler
+
+    metric = get_metric(metric="rmse", problem_type="regression")
+    with pytest.raises(ValueError):
+        ensembler = HardVotingEnsembler(problem_type="regression", metric=metric)
+
+
+def test_hard_voting_fails_multiclass_with_wrong_dimension():
+    from tabarena.simulation.ensemble import HardVotingEnsembler
+
+    y, preds = _make_binary_task(seed=7)
+    metric = get_metric(metric="log_loss", problem_type="multiclass")
+    ensembler = HardVotingEnsembler(problem_type="multiclass", metric=metric)
+    with pytest.raises(ValueError):
+        ensembler.fit(predictions=preds, labels=y)
+    with pytest.raises(ValueError):
+        ensembler.predict_proba(predictions=preds)
+    with pytest.raises(ValueError):
+        ensembler.predict(predictions=preds)
+
+
+@pytest.mark.parametrize("problem_type", ["binary", "multiclass"])
+def test_hard_voting_predictions(problem_type):
+    from tabarena.simulation.ensemble import HardVotingEnsembler
+
+    if problem_type == "binary":
+        preds = np.array(
+            [
+                [0.2, 0.7, 0.8, 0.7],
+                [0.4, 0.6, 0.5, 0.4],
+                [0.3, 0.6, 0.6, 0.4],
+            ],
+            dtype=np.float32,
+        )
+        expected_proba = np.array(
+            [0, 1, 5 / 6, 1 / 3],
+            dtype=np.float32,
+        )
+        expected_classes = np.array([0, 1, 1, 0])
+        metric = get_metric(metric="roc_auc", problem_type=problem_type)
+    else:
+        preds = np.array(
+            [
+                [
+                    [0.0, 0.1, 0.9],
+                    [0.2, 0.5, 0.3],
+                    [0.6, 0.1, 0.3],
+                ],
+                [
+                    [0.2, 0.4, 0.4],
+                    [0.2, 0.5, 0.3],
+                    [0.2, 0.7, 0.1],
+                ],
+                [
+                    [0.1, 0.1, 0.8],
+                    [0.2, 0.6, 0.2],
+                    [0.5, 0.4, 0.1],
+                ],
+            ],
+            dtype=np.float32,
+        )
+        expected_proba = np.array(
+            [
+                [0, 1 / 6, 5 / 6],
+                [0, 1, 0],
+                [2 / 3, 1 / 3, 0],
+            ],
+            dtype=np.float32,
+        )
+        expected_classes = np.array([2, 1, 0])
+        metric = get_metric(metric="log_loss", problem_type=problem_type)
+
+    ensembler = HardVotingEnsembler(problem_type=problem_type, metric=metric)
+
+    # new data (a copy) uses the full refit model
+    out_proba = ensembler.predict_proba(preds.copy())
+    out_classes = ensembler.predict(preds.copy())
+    np.testing.assert_allclose(out_proba, expected_proba, rtol=1e-6)
+    assert np.all(out_classes == expected_classes)
 
 
 # -------------------------


### PR DESCRIPTION
First PR for https://github.com/autogluon/tabarena/issues/334.

## Description of changes

Two new ensemblers and a task evaluator were added:

- `MedianEnsembler`: Ensembler that uses the median rule (robust soft voting in classification)
- `HardVotingEnsembler`: Ensembler for classification only that uses hard voting
- `NoPreprocessingTaskEvaluator`: Task Evaluator allowing ensemblers that use all predicted classes in multiclass training/prediction, not just extracted true classes. 

`NoPreprocessingTaskEvaluator` doesn't preprocess the base learner predictions before training / prediction, it only preprocesses the ensembler results for error estimation.

## Testing

All tests are in tests/tabarena/simulation/test_ensembler.py

Basic tests for the format of the ensemblers were added. Tests for their results on a toy example were also added.

Test to check that the new task evaluator had similar results to `TaskEvaluator` on a simple ensembler (`TopKAverageEnsembler`) was added.

- In the case of multiclass, small changes to the metric value were expected due to the particularities of `log_loss` preprocessing. We use the original float32 rather than the preprocessed float64, leading to a $2^{-23} \approx 10^{-6}$ estimation difference for the metric.
- This task evaluator is not expected to work well with Ensemble Selection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Note:

A very minor mistake in a test was also corrected