### PR TITLE
Fold/dataset scoping in generate_all_figs, plus three small fixes

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
@@ -113,6 +113,11 @@ class TabArenaExperimentBundle:
     """
     n_random_configs: int
     """Number of random hyperparameter configurations to run for each model"""
+    default_seed_config: str = "fold-config-wise"
+    """How bagged random seeds are assigned across configs and folds (an
+    :data:`~tabarena.utils.config_utils.AddSeed` value). The default gives each config its own
+    seed, varied across its folds. Use ``"static"`` for an ablation, where every config must share
+    a seed or the flip being measured is confounded with a seed change."""
     preprocessing_pipelines: list[str]
     """EXPERIMENTAL!
     Preprocessing pipelines to add to the configurations we want to run.
@@ -506,6 +511,7 @@ class TabArenaExperimentBundle:
             time_limit=time_limit,
             time_limit_with_preprocessing=time_limit_with_preprocessing,
             model_hyperparameters=model_hyperparameters,
+            default_seed_config=self.default_seed_config,
         )
 
     def _generate_autogluon_config(

--- a/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
@@ -1126,12 +1126,54 @@ class AbstractArenaContext:
         return df_results
 
     # ------------------------------------------------------------------ artifacts / simulation / plotting
+    @staticmethod
+    def _resolve_shared_task_scope(
+        name: str,
+        top_level: list | None,
+        compare_kwargs: dict,
+        tuning_trajectory_kwargs: dict,
+    ) -> list | None:
+        """Reduce a task-scoping argument given in up to three places to the one value both passes use.
+
+        ``datasets`` and ``folds`` scope the compare pass and the tuning-trajectory pass alike, so
+        they are accepted as top-level :meth:`generate_all_figs` arguments *and* inside either
+        kwargs dict (where callers used to put them). Whichever spelling is used, the value is
+        removed from the per-pass dicts and returned for both, which is what makes the two grids
+        impossible to desynchronize. Disagreeing values are an error rather than a precedence rule:
+        there is no reading of two different grids that keeps the outputs comparable.
+        """
+        sources: dict[str, list | None] = {}
+        for source, kwargs in (
+            ("compare_kwargs", compare_kwargs),
+            ("tuning_trajectory_kwargs", tuning_trajectory_kwargs),
+        ):
+            if name in kwargs:
+                sources[source] = kwargs.pop(name)
+        if top_level is not None:
+            sources[f"{name}="] = top_level
+
+        specified = {k: v for k, v in sources.items() if v is not None}
+        distinct = []
+        for value in specified.values():
+            if not any(value == seen for seen in distinct):
+                distinct.append(value)
+        if len(distinct) > 1:
+            detail = ", ".join(f"{k}{v!r}" for k, v in specified.items())
+            raise ValueError(
+                f"Conflicting {name!r} for generate_all_figs: {detail}. The leaderboard and the "
+                f"tuning trajectories must be computed over the same tasks; pass {name} once as a "
+                f"generate_all_figs argument.",
+            )
+        return distinct[0] if distinct else None
+
     # FIXME: Finish this, it is WIP
     def generate_all_figs(
         self,
         output_dir,
         subsets: list[list[str] | tuple[str, list[str]]] | str = "auto",
         new_results=None,
+        datasets: list[str] | None = None,
+        folds: list[int] | None = None,
         compare_kwargs=None,
         tuning_trajectory_kwargs=None,
         plot_compare: bool = True,
@@ -1154,6 +1196,16 @@ class AbstractArenaContext:
         (multiple ``n_configs`` rows per method) on the trajectory plot while the leaderboard keeps
         the single-point method results — in one call instead of two.
 
+        ``datasets`` and ``folds`` scope the tasks for the compare pass *and* the
+        tuning-trajectory pass, which must always see the same grid. They may equivalently be
+        given inside ``compare_kwargs`` / ``tuning_trajectory_kwargs``; wherever they appear they
+        are hoisted and shared, and conflicting values raise. Sharing them is not cosmetic: the
+        trajectory pass fills every task a method does not cover via ``fillna_metrics`` and then
+        drops any method carrying an imputed row (``exclude_imputed=True``), so a trajectory grid
+        wider than the leaderboard's silently deletes methods from the trajectory figures and CSVs
+        while the leaderboard still reports them. ``compare``-only task scoping (``tasks``) has no
+        trajectory counterpart and stays in ``compare_kwargs``.
+
         ``save_composite_leaderboard=True`` additionally aggregates the per-subset leaderboards
         into a single composite table (rows = (method, metric), one column per subset) written to
         ``<output_dir>/composite_leaderboard.csv`` plus color-graded PNG renderings — see
@@ -1174,6 +1226,13 @@ class AbstractArenaContext:
             tuning_trajectory_kwargs = {}
         if website_leaderboard_kwargs is None:
             website_leaderboard_kwargs = {}
+        # Hoist the shared task scope out of either kwargs dict so both passes get the same grid.
+        datasets = self._resolve_shared_task_scope(
+            "datasets", datasets, compare_kwargs, tuning_trajectory_kwargs,
+        )
+        folds = self._resolve_shared_task_scope(
+            "folds", folds, compare_kwargs, tuning_trajectory_kwargs,
+        )
         if save_composite_leaderboard and not plot_compare:
             raise ValueError(
                 "save_composite_leaderboard=True requires plot_compare=True: the composite is "
@@ -1186,6 +1245,8 @@ class AbstractArenaContext:
         subset_fig_kwargs = dict(
             output_dir=output_dir,
             new_results=new_results,
+            datasets=datasets,
+            folds=folds,
             compare_kwargs=compare_kwargs,
             tuning_trajectory_kwargs=tuning_trajectory_kwargs,
             plot_compare=plot_compare,
@@ -1229,6 +1290,8 @@ class AbstractArenaContext:
         *,
         output_dir: Path,
         new_results,
+        datasets: list[str] | None,
+        folds: list[int] | None,
         compare_kwargs: dict,
         tuning_trajectory_kwargs: dict,
         plot_compare: bool,
@@ -1268,6 +1331,8 @@ class AbstractArenaContext:
                 subset=subset,
                 new_results=new_results,
                 subset_label=output_suffix,
+                datasets=datasets,
+                folds=folds,
                 **compare_kwargs,
             )
             if save_website_leaderboard and lb_df is not None:
@@ -1298,6 +1363,8 @@ class AbstractArenaContext:
                 save_path=output_dir_subset / "tuning_trajectories",
                 subset=subset,
                 extra_results=trajectory_extra_results if trajectory_extra_results is not None else new_results,
+                datasets=datasets,
+                folds=folds,
                 **tuning_trajectory_kwargs,
             )
         if plot_runtime_per_method:

--- a/packages/tabarena/src/tabarena/contexts/tabarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/context.py
@@ -112,6 +112,13 @@ class TabArenaContext(AbstractArenaContext):
         "medium": SubsetPredicate(lambda df: df["max_train_rows"].between(10_001, 100_000), ("max_train_rows",)),
         "small": SubsetPredicate(lambda df: df["max_train_rows"] <= 10_000, ("max_train_rows",)),
         "tiny": SubsetPredicate(lambda df: df["max_train_rows"] <= 2_000, ("max_train_rows",)),
+        # `small` minus `tiny`, spelled out rather than a `between` so it stays exactly the
+        # complement whatever `max_train_rows` dtype is (a between(2_001, ...) would drop any
+        # non-integer row count in (2000, 2001]).
+        "2k-10k": SubsetPredicate(
+            lambda df: (df["max_train_rows"] > 2_000) & (df["max_train_rows"] <= 10_000),
+            ("max_train_rows",),
+        ),
         # native feature-count buckets (v0.1 has no after-preprocessing feature count)
         "low_features": SubsetPredicate(
             lambda df: df["n_features"] <= FEATURE_COUNT_THRESHOLD,

--- a/packages/tabflow_slurm/src/tabflow_slurm/setup/plan.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/setup/plan.py
@@ -331,12 +331,17 @@ class TabArenaBenchmarkPlan:
         return self._print_summary_and_collect(runs)
 
     def selected_model_names(self) -> list[str]:
-        """Unique benchmark model names across all jobs (first-appearance order)."""
+        """Unique benchmark *registry* model names across all jobs (first-appearance order).
+
+        Entries built from a `ConfigGenerator` carry the model class directly rather than a
+        registry name, so they contribute nothing here — there is no name to look a model up by,
+        and their weights come from the class (or an explicit checkpoint path) instead.
+        """
         names: list[str] = []
         for job in self.model_jobs:
             for entry in job._model_entries():
                 name = entry[0] if isinstance(entry, tuple) else getattr(entry, "name", None)
-                if name is not None and name not in names:
+                if isinstance(name, str) and name not in names:
                     names.append(name)
         return names
 

--- a/tests/tabarena/benchmark/experiment/test_bundle.py
+++ b/tests/tabarena/benchmark/experiment/test_bundle.py
@@ -30,6 +30,7 @@ from tabarena.benchmark.experiment.bundle import (
 EXPECTED_FIELD_NAMES = {
     "models",
     "n_random_configs",
+    "default_seed_config",
     "preprocessing_pipelines",
     "model_agnostic_preprocessing",
     "max_predict_batch_size",
@@ -51,6 +52,7 @@ EXPECTED_FIELD_NAMES = {
 # overridden). Subclass-specific expectations below extend this baseline.
 COMMON_INHERITED_DEFAULTS = {
     "models": [],
+    "default_seed_config": "fold-config-wise",
     "model_agnostic_preprocessing": True,
     "max_predict_batch_size": None,
     "sequential_local_fold_fitting": False,

--- a/tests/tabarena/contexts/test_generate_all_figs_task_scope.py
+++ b/tests/tabarena/contexts/test_generate_all_figs_task_scope.py
@@ -1,0 +1,87 @@
+"""`generate_all_figs` must hand the compare pass and the tuning-trajectory pass the same tasks.
+
+A wider trajectory grid is not a cosmetic difference: the trajectory pass fills every task a
+method does not cover and then drops any method carrying an imputed row, so the leaderboard can
+report a method the trajectory figures silently omit.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+
+_resolve = AbstractArenaContext._resolve_shared_task_scope
+
+
+def test_top_level_value_is_returned_and_dicts_untouched():
+    compare_kwargs, trajectory_kwargs = {"plot": False}, {"file_ext": ".png"}
+    assert _resolve("folds", [0, 1, 2], compare_kwargs, trajectory_kwargs) == [0, 1, 2]
+    assert compare_kwargs == {"plot": False}
+    assert trajectory_kwargs == {"file_ext": ".png"}
+
+
+def test_absent_everywhere_is_none():
+    assert _resolve("datasets", None, {}, {}) is None
+
+
+@pytest.mark.parametrize("source", ["compare_kwargs", "tuning_trajectory_kwargs"])
+def test_value_in_either_dict_is_hoisted_out(source):
+    """Callers that passed the scope to one pass now get it applied to both, not just that one."""
+    dicts = {"compare_kwargs": {}, "tuning_trajectory_kwargs": {}}
+    dicts[source]["datasets"] = ["a", "b"]
+    assert _resolve("datasets", None, **dicts) == ["a", "b"]
+    # Popped, so the caller cannot also forward it positionally and duplicate the argument.
+    assert dicts["compare_kwargs"] == {}
+    assert dicts["tuning_trajectory_kwargs"] == {}
+
+
+def test_agreeing_values_across_sources_collapse_to_one():
+    assert _resolve("folds", [0], {"folds": [0]}, {"folds": [0]}) == [0]
+
+
+def test_none_in_a_dict_does_not_override_a_real_value():
+    assert _resolve("folds", [0, 1], {"folds": None}, {}) == [0, 1]
+
+
+@pytest.mark.parametrize(
+    ("top_level", "compare_kwargs", "trajectory_kwargs"),
+    [
+        ([0, 1], {"folds": [0, 1, 2]}, {}),
+        (None, {"folds": [0]}, {"folds": [1]}),
+        ([0], {}, {"folds": [0, 1]}),
+    ],
+)
+def test_conflicting_values_raise(top_level, compare_kwargs, trajectory_kwargs):
+    with pytest.raises(ValueError, match="Conflicting 'folds'"):
+        _resolve("folds", top_level, compare_kwargs, trajectory_kwargs)
+
+
+def test_generate_all_figs_forwards_the_same_scope_to_both_passes(monkeypatch, tmp_path):
+    """End-to-end on the wiring: whichever dict the caller used, both passes see one grid."""
+    seen: dict[str, dict] = {}
+
+    def fake_compare(self, output_dir, **kwargs):
+        seen["compare"] = kwargs
+        return pd.DataFrame()
+
+    def fake_plot(self, save_path, **kwargs):
+        seen["trajectory"] = kwargs
+
+    monkeypatch.setattr(AbstractArenaContext, "compare", fake_compare)
+    monkeypatch.setattr(AbstractArenaContext, "plot_tuning_trajectories", fake_plot)
+
+    AbstractArenaContext.generate_all_figs(
+        object.__new__(AbstractArenaContext),
+        output_dir=tmp_path,
+        subsets=[[]],
+        # Deliberately given the old way, on the compare side only.
+        compare_kwargs={"folds": [0, 1, 2], "datasets": ["d1"]},
+        plot_compare=True,
+        plot_tuning_trajectories=True,
+    )
+
+    for pass_name in ("compare", "trajectory"):
+        assert seen[pass_name]["folds"] == [0, 1, 2], pass_name
+        assert seen[pass_name]["datasets"] == ["d1"], pass_name


### PR DESCRIPTION
Four independent changes, one commit each — happy to split into separate PRs if preferred.

### Share `folds` / `datasets` between the compare and tuning-trajectory passes (`5edd689e`)

`generate_all_figs` forwarded task scoping from `compare_kwargs` to the compare pass only, so the leaderboard and the trajectories could silently describe different grids.

That is not cosmetic. The trajectory pass fills every task a method does not cover (`fillna_metrics`) and then drops any method carrying an imputed row (`exclude_imputed=True`), so a trajectory grid wider than the leaderboard's **deletes methods from the trajectory figures and CSVs while the leaderboard still reports them** — and it does so silently, as one more name in an `Excluding N imputed methods:` line alongside genuinely partial models.

`datasets` and `folds` are now top-level `generate_all_figs` arguments forwarded to both passes. They may still be given inside either kwargs dict, where they are hoisted and shared, so existing callers get the shared behaviour rather than the old compare-only behaviour. Conflicting values raise instead of a precedence rule: there is no reading of two different grids that keeps the outputs comparable. `compare`-only scoping (`tasks`) has no trajectory counterpart and stays in `compare_kwargs`.

10 tests in `tests/tabarena/contexts/test_generate_all_figs_task_scope.py`, including an end-to-end one asserting both passes receive the same grid when the caller uses the old spelling.

### `default_seed_config` on experiment bundles (`c55663c7`)

The bagged-seed policy was fixed at `"fold-config-wise"`. That is wrong for an ablation, where every config must share a seed or the hyperparameter flip being measured is confounded with a seed change. Exposed on the bundle, defaulting to the previous behaviour.

### `2k-10k` subset predicate (`f9afe7f3`)

Datasets between 2,000 and 10,000 training rows had no name of their own — the band was only reachable as `small` minus `tiny`.

### Non-string model entries in the SLURM plan (`0f4abc69`)

`selected_model_names` assumed every entry was a model name, so a plan built from `ConfigGenerator` objects crashed before scheduling anything.

## Testing

ruff clean; 966 tests pass across `tests/tabarena/contexts`, `tests/tabarena/benchmark`, `tests/tabarena/plot` and `tests/tabflow_slurm`.

## Note

`bundle.py` / `test_bundle.py` are also touched by the `preset-hyperparameters-injection` branch. This branch does not depend on that work (the change applies cleanly to `main` on its own), but expect a small textual conflict if both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)