### PR TITLE
Recover per-fold validation indices for refit_folds models

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/exec_models/autogluon.py
+++ b/packages/tabarena/src/tabarena/benchmark/exec_models/autogluon.py
@@ -605,22 +605,28 @@ class AGSingleBagWrapper(AGSingleWrapper):
         if model is None:
             model = self._load_model()
         X, y = self.predictor.load_data_internal()
-        all_kfolds = []
-        # TODO: Make this a bagged ensemble method
-        if model._child_oof:
-            all_kfolds = [(None, X.index.values)]
+
+        get_oof_fold_val_idx = getattr(model, "get_oof_fold_val_idx", None)
+        if get_oof_fold_val_idx is not None:
+            val_idx_per_child = get_oof_fold_val_idx(X=X, y=y)
         else:
-            for n_repeat, k in enumerate(model._k_per_n_repeat):
-                kfolds = model._cv_splitters[n_repeat].split(X=X, y=y)
-                cur_kfolds = kfolds[n_repeat * k : (n_repeat + 1) * k]
-                all_kfolds += cur_kfolds
+            # LEGACY: drop this branch once AutoGluon >= 1.6.2 is the floor, and call
+            # `model.get_oof_fold_val_idx` unconditionally.
+            #
+            # It reproduces that method for older AutoGluon, where a bagged model exposes only
+            # its splitters. Note what it *cannot* reproduce: a `refit_folds` model there reports
+            # a single child covering every row, because the folds that made its OOF were
+            # discarded along with their splitters, so the fold structure is simply unavailable.
+            all_kfolds = []
+            if model._child_oof:
+                all_kfolds = [(None, X.index.values)]
+            else:
+                for n_repeat, k in enumerate(model._k_per_n_repeat):
+                    kfolds = model._cv_splitters[n_repeat].split(X=X, y=y)
+                    all_kfolds += kfolds[n_repeat * k : (n_repeat + 1) * k]
+            val_idx_per_child = [val_idx for _train_idx, val_idx in all_kfolds]
 
-        val_idx_per_child = []
-        for _fold_idx, (_train_idx, val_idx) in enumerate(all_kfolds):
-            val_idx = pd.to_numeric(val_idx, downcast="integer")  # memory opt
-            val_idx_per_child.append(val_idx)
-
-        return val_idx_per_child
+        return [pd.to_numeric(val_idx, downcast="integer") for val_idx in val_idx_per_child]  # memory opt
 
     # TODO: Can avoid predicting on test twice by doing it all in one go
     def get_per_child_test(self, X_test: pd.DataFrame, model=None) -> list[np.ndarray]:

--- a/packages/tabarena/src/tabarena/benchmark/result/ag_bag_result.py
+++ b/packages/tabarena/src/tabarena/benchmark/result/ag_bag_result.py
@@ -68,20 +68,29 @@ class AGBagResult(ConfigResult):
         bag_info = self.result["simulation_artifacts"]["bag_info"]
         if "pred_proba_test_per_child" in bag_info:
             bag_info["pred_test_per_child"] = bag_info.pop("pred_proba_test_per_child")
-        len(self.result["simulation_artifacts"]["y_val_idx"])
         if "val_idx_per_child" in bag_info and "pred_val_per_child" not in bag_info:
             # TODO: verify nothing break if we dont assert anymore
             # Ensure no repeated bagging
             # assert num_samples_val == sum([len(val_idx_child) for val_idx_child in bag_info["val_idx_per_child"]])
             # convert to pred_val_per_child
             pred_val_per_child = []
-            if len(bag_info["val_idx_per_child"]) == 1:
-                # FIXME: Bug in AutoGluon's output! Wrong indices. This logic fixes that.
+            # LEGACY: AutoGluon < 1.6.2 emitted `X.index` *labels* for a single-child model
+            # (`_child_oof` / pre-fix `refit_folds`) while every other case emitted positions.
+            # `get_oof_fold_val_idx` now returns positions uniformly, so only older artifacts
+            # need the remap; drop this branch once none are in circulation.
+            #
+            # Detected from the values rather than a version marker, which the artifacts do not
+            # carry: positions are exactly `arange(n)`, whereas labels are the training rows in
+            # fit order. Where an index happens to be a sorted RangeIndex the two coincide and
+            # the remap would be a no-op anyway, so the test cannot pick the wrong branch.
+            num_samples_val = len(self.result["simulation_artifacts"]["y_val_idx"])
+            val_idx_first = np.asarray(bag_info["val_idx_per_child"][0])
+            if len(bag_info["val_idx_per_child"]) == 1 and not np.array_equal(
+                val_idx_first, np.arange(num_samples_val)
+            ):
                 y_val_idx = self.result["simulation_artifacts"]["y_val_idx"]
                 value_to_index = {value: idx for idx, value in enumerate(y_val_idx)}
-                val_idx_child = bag_info["val_idx_per_child"][0]
-                val_idx_child_iloc = np.array([value_to_index[v] for v in val_idx_child])
-                bag_info["val_idx_per_child"][0] = val_idx_child_iloc
+                bag_info["val_idx_per_child"][0] = np.array([value_to_index[v] for v in val_idx_first])
             for val_idx_child in bag_info["val_idx_per_child"]:
                 pred_val_child_cur = self.result["simulation_artifacts"]["pred_val"][val_idx_child]
                 pred_val_per_child.append(pred_val_child_cur)


### PR DESCRIPTION
Depends on autogluon/autogluon#5875 for the full benefit, but is safe to merge before it — see Compatibility.

## Issue

A `refit_folds` model (every foundation-model wrapper sets it) is a single child fit on all the data, while its out-of-fold predictions were made by folds that the refit discarded. AutoGluon marked such a model `_child_oof`, so `get_per_child_val_idx` reported **one pseudo-fold covering every training row**, and `bag_info["val_idx_per_child"]` lost which fold produced each OOF row. Bagged models that are not refit were unaffected — they still recorded one index array per fold.

The predictions were never wrong; only the fold attribution was missing. It matters for anything that wants to work per-fold, e.g. restricting ensemble weight selection to a subset of the folds.

## Change

**Use AutoGluon's `get_oof_fold_val_idx`.** It answers "which rows did each child validate?" for every OOF provenance (bagged, refit, child-OOF), so `get_per_child_val_idx` no longer branches on `_child_oof` or reaches into `_cv_splitters`. The hand-rolled branching is kept only for older AutoGluon and is marked for removal once `>= 1.6.2` is the floor. On older AutoGluon a refit genuinely cannot report its folds — the splitters were discarded with them — so that path is unchanged, not silently degraded.

**Make the single-child index remap conditional.** AutoGluon < 1.6.2 emitted `X.index` *labels* for a single-child model while every other case emitted positions — the existing `# FIXME: Bug in AutoGluon's output!`. #5875 makes it emit positions uniformly, so an unconditional remap would corrupt current artifacts.

The artifacts carry no version marker (checked), so the two are distinguished by value: positions are exactly `arange(n)`, labels are the training rows in fit order. Where an index happens to be a sorted `RangeIndex` the two coincide and the remap is a no-op, so the test cannot pick a harmful branch.

## Compatibility

Both directions verified by reconstructing `pred_val` from `bag_info` and comparing to the artifact's own OOF vector (`np.allclose`), on real artifacts:

| artifact | children | indices stored as | reconstructs |
|---|---|---|---|
| pre-#5875 refit | 1 | labels | ✅ |
| repaired refit | 8 | positions | ✅ |
| current bagged (LightGBM) | 2 | positions | ✅ |
| current refit | 2 | positions | ✅ |
| post-#5875 child-OOF | 1 | positions | ✅ |

That last row is why the remap has to be conditional: the previous unconditional code fails on it, with 331/1002 positions absent from the label map (`KeyError`). So this should land **before or with** #5875, not after.

## Testing

ruff clean; 725 tests pass across `tests/tabarena/benchmark` and `tests/tabarena/end_to_end`. End-to-end on a 2-fold bagged run of one GBDT and one foundation model: both now record one index array per fold, and the refit still contributes a single test prediction, which is what a refit genuinely produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)