### PR TITLE
Add a temporary flag to restore the pre-#488 Elo solver tolerance

### DIFF
--- a/packages/bencheval/src/bencheval/elo_utils.py
+++ b/packages/bencheval/src/bencheval/elo_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 from collections import defaultdict
 
 import numpy as np
@@ -21,16 +22,31 @@ ELO_SOLVER_TOL = 1e-10
 #: after ~7 iterations on a leaderboard-sized field, short of the Bradley-Terry maximum.
 LEGACY_ELO_SOLVER_TOL = 1e-4
 
+#: Env var equivalent of :data:`USE_LEGACY_ELO_SOLVER_TOL`, for turning the legacy fit on without
+#: touching code — a CLI run, a CI job, or a one-off comparison.
+LEGACY_ELO_SOLVER_TOL_ENV_VAR = "TABARENA_LEGACY_ELO_SOLVER_TOL"
+
 #: TEMPORARY. Set True to compute Elo the pre-tightening way, for reproducing numbers published
-#: before the change or for bisecting a leaderboard difference against it. Read through
-#: :func:`elo_solver_tol` rather than captured at import, so flipping it at runtime takes effect.
+#: before the change or for bisecting a leaderboard difference against it.
 #: Remove once nothing needs to reproduce the older ratings.
 USE_LEGACY_ELO_SOLVER_TOL = False
 
 
+def use_legacy_elo_solver_tol() -> bool:
+    """Whether the pre-tightening tolerance is requested, by module flag or env var.
+
+    Both are consulted on every call rather than captured at import, so either can be changed
+    part-way through a process — which is the point of a flag whose job is reproducing an older
+    number alongside the current one.
+    """
+    if USE_LEGACY_ELO_SOLVER_TOL:
+        return True
+    return os.environ.get(LEGACY_ELO_SOLVER_TOL_ENV_VAR, "").strip().lower() in ("1", "true", "yes")
+
+
 def elo_solver_tol() -> float:
-    """The lbfgs tolerance for the Elo fit, honouring :data:`USE_LEGACY_ELO_SOLVER_TOL`."""
-    return LEGACY_ELO_SOLVER_TOL if USE_LEGACY_ELO_SOLVER_TOL else ELO_SOLVER_TOL
+    """The lbfgs tolerance for the Elo fit, honouring :func:`use_legacy_elo_solver_tol`."""
+    return LEGACY_ELO_SOLVER_TOL if use_legacy_elo_solver_tol() else ELO_SOLVER_TOL
 
 
 class EloHelper:

--- a/packages/bencheval/src/bencheval/elo_utils.py
+++ b/packages/bencheval/src/bencheval/elo_utils.py
@@ -17,6 +17,21 @@ logger = logging.getLogger(__name__)
 # `compute_elo`, which is dominated by building the battles.
 ELO_SOLVER_TOL = 1e-10
 
+#: scikit-learn's default, and what shipped before the tolerance was tightened. lbfgs meets it
+#: after ~7 iterations on a leaderboard-sized field, short of the Bradley-Terry maximum.
+LEGACY_ELO_SOLVER_TOL = 1e-4
+
+#: TEMPORARY. Set True to compute Elo the pre-tightening way, for reproducing numbers published
+#: before the change or for bisecting a leaderboard difference against it. Read through
+#: :func:`elo_solver_tol` rather than captured at import, so flipping it at runtime takes effect.
+#: Remove once nothing needs to reproduce the older ratings.
+USE_LEGACY_ELO_SOLVER_TOL = False
+
+
+def elo_solver_tol() -> float:
+    """The lbfgs tolerance for the Elo fit, honouring :data:`USE_LEGACY_ELO_SOLVER_TOL`."""
+    return LEGACY_ELO_SOLVER_TOL if USE_LEGACY_ELO_SOLVER_TOL else ELO_SOLVER_TOL
+
 
 class EloHelper:
     def __init__(
@@ -69,7 +84,7 @@ class EloHelper:
                 )
                 SeriesOut = pd.Series(elo_scores, index=models.index)
             else:
-                lr = LogisticRegression(fit_intercept=False, max_iter=max_iter, C=1e6, tol=ELO_SOLVER_TOL)
+                lr = LogisticRegression(fit_intercept=False, max_iter=max_iter, C=1e6, tol=elo_solver_tol())
                 lr.fit(X, Y, sample_weight=sample_weight)
                 coef = lr.coef_[0]
                 # map coef -> ELO
@@ -113,7 +128,7 @@ class EloHelper:
                     models=models,
                 )
             else:
-                lr = LogisticRegression(fit_intercept=False, max_iter=max_iter, C=1e6, tol=ELO_SOLVER_TOL)
+                lr = LogisticRegression(fit_intercept=False, max_iter=max_iter, C=1e6, tol=elo_solver_tol())
                 lr.fit(X, Y, sample_weight=sample_weight)
                 elo_scores = SCALE * lr.coef_[0] + INIT_RATING
 
@@ -916,7 +931,7 @@ class EloHelper:
                 X_fit, Y_fit, sw_fit = X2, Y2, sw
 
             # Fit LR on the fixed design with per-draw weights
-            lr = LogisticRegression(fit_intercept=False, C=1e6, solver=solver, max_iter=max_iter, tol=ELO_SOLVER_TOL)
+            lr = LogisticRegression(fit_intercept=False, C=1e6, solver=solver, max_iter=max_iter, tol=elo_solver_tol())
             lr.fit(X_fit, Y_fit, sample_weight=sw_fit)
 
             # Map coefficients -> ELO

--- a/tests/bencheval/test_elo_utils.py
+++ b/tests/bencheval/test_elo_utils.py
@@ -116,3 +116,39 @@ def test_legacy_flag_reproduces_the_looser_fit(monkeypatch):
     assert not np.allclose(legacy.to_numpy(), converged.reindex(legacy.index).to_numpy())
     # Both still order the field the same way; only the scale differs.
     assert legacy.rank().equals(converged.reindex(legacy.index).rank())
+
+
+def test_env_var_enables_the_legacy_tolerance(monkeypatch):
+    """The env var turns the legacy fit on without touching code, and is read per call."""
+    from bencheval import elo_utils
+
+    for truthy in ("1", "true", "TRUE", "yes", " on ".strip(), "Yes"):
+        monkeypatch.setenv(elo_utils.LEGACY_ELO_SOLVER_TOL_ENV_VAR, truthy)
+        expected = truthy.strip().lower() in ("1", "true", "yes")
+        assert elo_utils.use_legacy_elo_solver_tol() is expected, truthy
+
+    for falsey in ("0", "false", "no", ""):
+        monkeypatch.setenv(elo_utils.LEGACY_ELO_SOLVER_TOL_ENV_VAR, falsey)
+        assert elo_utils.use_legacy_elo_solver_tol() is False, falsey
+        assert elo_utils.elo_solver_tol() == elo_utils.ELO_SOLVER_TOL
+
+    monkeypatch.delenv(elo_utils.LEGACY_ELO_SOLVER_TOL_ENV_VAR, raising=False)
+    assert elo_utils.use_legacy_elo_solver_tol() is False
+
+
+def test_module_flag_and_env_var_are_independent(monkeypatch):
+    """Either switch alone is enough; neither can turn the other off."""
+    from bencheval import elo_utils
+
+    monkeypatch.delenv(elo_utils.LEGACY_ELO_SOLVER_TOL_ENV_VAR, raising=False)
+    monkeypatch.setattr(elo_utils, "USE_LEGACY_ELO_SOLVER_TOL", True)
+    assert elo_utils.elo_solver_tol() == elo_utils.LEGACY_ELO_SOLVER_TOL
+
+    monkeypatch.setattr(elo_utils, "USE_LEGACY_ELO_SOLVER_TOL", False)
+    monkeypatch.setenv(elo_utils.LEGACY_ELO_SOLVER_TOL_ENV_VAR, "1")
+    assert elo_utils.elo_solver_tol() == elo_utils.LEGACY_ELO_SOLVER_TOL
+
+    # A falsey env var does not override an explicitly set module flag.
+    monkeypatch.setattr(elo_utils, "USE_LEGACY_ELO_SOLVER_TOL", True)
+    monkeypatch.setenv(elo_utils.LEGACY_ELO_SOLVER_TOL_ENV_VAR, "0")
+    assert elo_utils.elo_solver_tol() == elo_utils.LEGACY_ELO_SOLVER_TOL

--- a/tests/bencheval/test_elo_utils.py
+++ b/tests/bencheval/test_elo_utils.py
@@ -55,3 +55,64 @@ class TestEloHelper:
             assert elo_scores[0] < elo_scores[1]
         else:
             assert elo_scores[0] == elo_scores[1]
+
+
+def test_elo_solver_tol_defaults_to_the_converged_value():
+    """The flag is off by default: a fresh import computes the converged ratings."""
+    from bencheval import elo_utils
+
+    assert elo_utils.USE_LEGACY_ELO_SOLVER_TOL is False
+    assert elo_utils.elo_solver_tol() == elo_utils.ELO_SOLVER_TOL
+
+
+def test_legacy_flag_is_read_at_call_time(monkeypatch):
+    """Toggling the flag takes effect without re-importing, so it can be flipped per run."""
+    from bencheval import elo_utils
+
+    monkeypatch.setattr(elo_utils, "USE_LEGACY_ELO_SOLVER_TOL", True)
+    assert elo_utils.elo_solver_tol() == elo_utils.LEGACY_ELO_SOLVER_TOL
+    monkeypatch.setattr(elo_utils, "USE_LEGACY_ELO_SOLVER_TOL", False)
+    assert elo_utils.elo_solver_tol() == elo_utils.ELO_SOLVER_TOL
+
+
+def test_legacy_flag_reproduces_the_looser_fit(monkeypatch):
+    """With the flag on, ratings are the under-converged ones: shrunk toward the field mean.
+
+    The ladder has to be wide for this to be measurable: the shrinkage grows with distance from
+    the field mean, so on a narrow field it is a fraction of an Elo point and the comparison is
+    noise. At +/-6 in log-strength the looser fit is a clear ~2 Elo short at the extremes.
+    """
+    import numpy as np
+    import pandas as pd
+
+    from bencheval import elo_utils
+    from bencheval.evaluator import BenchmarkEvaluator
+
+    n_methods, n_tasks = 12, 400
+    rng = np.random.default_rng(0)
+    strengths = np.linspace(6.0, -6.0, n_methods)
+    err = -(strengths[:, None] + rng.gumbel(size=(n_methods, n_tasks)))
+    df = pd.DataFrame({
+        "method": np.repeat([f"m{i}" for i in range(n_methods)], n_tasks),
+        "task": np.tile([f"t{j}" for j in range(n_tasks)], n_methods),
+        "metric_error": err.ravel(),
+    })
+    evaluator = BenchmarkEvaluator(task_col="task", error_col="metric_error")
+
+    def elo() -> pd.Series:
+        out = evaluator.compute_elo(
+            results_per_task=df, BOOTSTRAP_ROUNDS=1, include_quantiles=False, round_decimals=None
+        )
+        return (out["elo"] if isinstance(out, pd.DataFrame) else out).astype(float)
+
+    converged = elo()
+    monkeypatch.setattr(elo_utils, "USE_LEGACY_ELO_SOLVER_TOL", True)
+    legacy = elo()
+
+    def spread(s: pd.Series) -> float:
+        return float(s.max() - s.min())
+
+    assert spread(legacy) < spread(converged), "the looser fit should report a compressed spread"
+    assert not np.allclose(legacy.to_numpy(), converged.reindex(legacy.index).to_numpy())
+    # Both still order the field the same way; only the scale differs.
+    assert legacy.rank().equals(converged.reindex(legacy.index).rank())

--- a/tests/bencheval/test_elo_utils.py
+++ b/tests/bencheval/test_elo_utils.py
@@ -92,11 +92,13 @@ def test_legacy_flag_reproduces_the_looser_fit(monkeypatch):
     rng = np.random.default_rng(0)
     strengths = np.linspace(6.0, -6.0, n_methods)
     err = -(strengths[:, None] + rng.gumbel(size=(n_methods, n_tasks)))
-    df = pd.DataFrame({
-        "method": np.repeat([f"m{i}" for i in range(n_methods)], n_tasks),
-        "task": np.tile([f"t{j}" for j in range(n_tasks)], n_methods),
-        "metric_error": err.ravel(),
-    })
+    df = pd.DataFrame(
+        {
+            "method": np.repeat([f"m{i}" for i in range(n_methods)], n_tasks),
+            "task": np.tile([f"t{j}" for j in range(n_tasks)], n_methods),
+            "metric_error": err.ravel(),
+        }
+    )
     evaluator = BenchmarkEvaluator(task_col="task", error_col="metric_error")
 
     def elo() -> pd.Series:


### PR DESCRIPTION
## Why

#488 tightened the lbfgs tolerance of the Elo fit from scikit-learn's default `1e-4` to `1e-10`, so the fit reaches the Bradley-Terry maximum instead of stopping ~7 iterations in. That shifted every rating a little — up to ~6 Elo on the weakest method in the field, with no rank changes.

That is the right default, but it makes previously published Elo numbers unreproducible from source. Anyone checking an older figure, or bisecting a leaderboard difference to decide whether it came from this change or from the data, currently has to patch the constant by hand.

## Change

Two ways to ask for the old behaviour, both off by default:

```python
USE_LEGACY_ELO_SOLVER_TOL = False                          # module flag
LEGACY_ELO_SOLVER_TOL_ENV_VAR = "TABARENA_LEGACY_ELO_SOLVER_TOL"   # env var
```

```bash
TABARENA_LEGACY_ELO_SOLVER_TOL=1 python your_leaderboard_script.py
```

- **Defaults to off** — no behaviour change unless one is set.
- **Either switch alone is enough**, and neither can turn the other off.
- Both are consulted **per call** rather than captured at import, so either can be changed part-way through a process — which is the point of a flag whose job is producing an old number alongside the current one.
- Truthy parsing (`1` / `true` / `yes`, case- and whitespace-insensitive) matches `TABARENA_DISABLE_RESULT_COMPRESSION`.
- `ELO_SOLVER_TOL` and the `C=1e6` penalty are untouched; only the tolerance is swapped.

Marked temporary, to be removed once nothing needs to reproduce the older ratings.

## Verified end to end

```
$ python check.py
legacy=False  tol=1e-10  spread=2047.50

$ TABARENA_LEGACY_ELO_SOLVER_TOL=1 python check.py
legacy=True   tol=1e-04  spread=2043.94
```

## Testing

Five tests in `tests/bencheval/test_elo_utils.py`: the default is off; the module flag is read at call time in both directions; the env var accepts the truthy set and rejects the rest; the two switches are independent; and with the legacy fit on, ratings show the under-converged compressed spread with unchanged ordering.

That last test needs a wide field to be meaningful. The shrinkage grows with distance from the field mean, so on a narrow ladder it is a fraction of an Elo point and the assertion is testing noise; at ±6 in log-strength the looser fit is a clear ~2 Elo short at the extremes. That is what the test uses.

`pytest tests/` — 1488 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)