### PR TITLE
Fix ruff format failures on main

### DIFF
--- a/packages/bencheval/src/bencheval/elo_utils.py
+++ b/packages/bencheval/src/bencheval/elo_utils.py
@@ -916,9 +916,7 @@ class EloHelper:
                 X_fit, Y_fit, sw_fit = X2, Y2, sw
 
             # Fit LR on the fixed design with per-draw weights
-            lr = LogisticRegression(
-                fit_intercept=False, C=1e6, solver=solver, max_iter=max_iter, tol=ELO_SOLVER_TOL
-            )
+            lr = LogisticRegression(fit_intercept=False, C=1e6, solver=solver, max_iter=max_iter, tol=ELO_SOLVER_TOL)
             lr.fit(X_fit, Y_fit, sample_weight=sw_fit)
 
             # Map coefficients -> ELO

--- a/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
@@ -1228,10 +1228,16 @@ class AbstractArenaContext:
             website_leaderboard_kwargs = {}
         # Hoist the shared task scope out of either kwargs dict so both passes get the same grid.
         datasets = self._resolve_shared_task_scope(
-            "datasets", datasets, compare_kwargs, tuning_trajectory_kwargs,
+            "datasets",
+            datasets,
+            compare_kwargs,
+            tuning_trajectory_kwargs,
         )
         folds = self._resolve_shared_task_scope(
-            "folds", folds, compare_kwargs, tuning_trajectory_kwargs,
+            "folds",
+            folds,
+            compare_kwargs,
+            tuning_trajectory_kwargs,
         )
         if save_composite_leaderboard and not plot_compare:
             raise ValueError(


### PR DESCRIPTION
## Issue

`ruff format --check .` currently fails on `main`:

```
Would reformat: packages/bencheval/src/bencheval/elo_utils.py
Would reformat: packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
2 files would be reformatted, 536 files already formatted
```

CI runs this (`.github/workflows/pytest-pytest.yml`, `ruff format --check .`), so `main` is red on that step.

Both are mine, from recently merged PRs:

- `elo_utils.py` — the `LogisticRegression(...)` call I wrapped across lines in #488, which fits within the 119-character limit and should be one line.
- `abstract_arena_context.py` — magic trailing commas in the two `_resolve_shared_task_scope` calls from #484, which force each argument onto its own line.

`ruff check .` passes; this is formatting only.

## Change

Ran `ruff format` on the two files, using the version CI pins (**0.14.0**) rather than a newer local one, so the result matches what CI will check. Verified afterwards with the same version:

```
$ ruff check .
All checks passed!
$ ruff format --check .
538 files already formatted
```

No behaviour change. `pytest tests/` — 1483 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)