### PR TITLE
Compute Elo from per-task ranks by default, skipping the battle table

### DIFF
--- a/packages/bencheval/src/bencheval/elo_utils.py
+++ b/packages/bencheval/src/bencheval/elo_utils.py
@@ -49,6 +49,27 @@ def elo_solver_tol() -> float:
     return LEGACY_ELO_SOLVER_TOL if use_legacy_elo_solver_tol() else ELO_SOLVER_TOL
 
 
+#: Env var equivalent of :data:`USE_FAST_ELO`, for turning the rank path off without touching code.
+DISABLE_FAST_ELO_ENV_VAR = "TABARENA_DISABLE_FAST_ELO"
+
+#: Solve Bradley-Terry from per-task ranks instead of a materialised battle table when the results
+#: allow it. Same ratings, but cost is linear rather than quadratic in the number of methods.
+USE_FAST_ELO = True
+
+
+def use_fast_elo() -> bool:
+    """Whether the rank path may be used, by module flag and env var.
+
+    The legacy tolerance wins: its whole purpose is reproducing ratings from a specific solver
+    run, so a request for it has to reach that solver rather than an equivalent-but-different one.
+    """
+    if use_legacy_elo_solver_tol():
+        return False
+    if not USE_FAST_ELO:
+        return False
+    return os.environ.get(DISABLE_FAST_ELO_ENV_VAR, "").strip().lower() not in ("1", "true", "yes")
+
+
 class EloHelper:
     def __init__(
         self,
@@ -64,6 +85,138 @@ class EloHelper:
 
         self.method_1 = f"{self.method_col}_1"
         self.method_2 = f"{self.method_col}_2"
+
+    def _pivot_errors(self, results_per_task: pd.DataFrame) -> pd.DataFrame:
+        """Errors as a method x unit matrix, one column per unit that battles are paired within.
+
+        That unit is ``(task, split)`` whenever a split column is set, matching
+        :meth:`convert_results_to_battles`, so both paths see the same schedule.
+
+        Only observed units become columns. The (task, split) grid is ragged -- tasks differ in how
+        many splits they have -- so materialising the full cross-product would invent units that no
+        method ran and make every real schedule look incomplete.
+        """
+        on_cols = [self.task_col] if self.split_col is None else [self.task_col, self.split_col]
+        return results_per_task.pivot_table(index=self.method_col, columns=on_cols, values=self.error_col)
+
+    def _rank_win_matrix(self, results_per_task: pd.DataFrame) -> tuple[pd.Index, np.ndarray]:
+        """Per-task win totals implied by the per-unit ranks, shape ``(n_methods, n_tasks)``.
+
+        A method's rank on a unit is one plus the number of methods that beat it, so ``n_methods -
+        rank`` is its win count there -- ties included at half a win each, since ranks are averaged
+        over them. Units are then weighted by ``1 / n_splits(task)`` and summed within their task,
+        so every task contributes total weight 1 however many splits it ran. That is the weighting
+        :meth:`convert_results_to_battles` attaches to each battle, and getting it wrong tilts the
+        ratings toward whichever tasks happen to have the most splits.
+
+        Raises:
+            ValueError: if any method is missing a unit. Win totals are only a sufficient statistic
+                for Bradley-Terry when the schedule is complete and balanced, so this shortcut
+                would otherwise silently give a different answer.
+        """
+        wide = self._pivot_errors(results_per_task=results_per_task)
+        if wide.isna().to_numpy().any():
+            missing = int(wide.isna().to_numpy().sum())
+            raise ValueError(
+                f"The rank path requires every method to have every task; {missing} (method, task) "
+                f"pair(s) are missing. Win totals are only a sufficient statistic for Bradley-Terry "
+                f"when the schedule is complete and balanced."
+            )
+        if len(wide) < 2:
+            raise ValueError(f"The rank path needs at least two methods to compare, got {len(wide)}.")
+
+        n_methods = len(wide)
+        wins_per_unit = n_methods - wide.rank(axis=0, method="average", ascending=True).to_numpy()
+
+        units = wide.columns
+        tasks = units.to_numpy() if self.split_col is None else units.get_level_values(self.task_col).to_numpy()
+        _, task_of_unit = np.unique(tasks, return_inverse=True)
+        n_tasks = int(task_of_unit.max()) + 1
+        weights = 1.0 / np.bincount(task_of_unit)[task_of_unit]
+
+        # Sum each unit's weighted wins into its task's column.
+        unit_to_task = np.zeros((len(task_of_unit), n_tasks))
+        unit_to_task[np.arange(len(task_of_unit)), task_of_unit] = 1.0
+        return wide.index, (wins_per_unit * weights) @ unit_to_task
+
+    def can_compute_elo_from_ranks(self, results_per_task: pd.DataFrame) -> bool:
+        """Whether the rank path applies: at least two methods, no duplicate or missing units."""
+        on_cols = [self.task_col] if self.split_col is None else [self.task_col, self.split_col]
+        if results_per_task.duplicated(subset=[self.method_col, *on_cols]).any():
+            # The battle path rejects these outright; let it raise rather than averaging them away.
+            return False
+        wide = self._pivot_errors(results_per_task=results_per_task)
+        return len(wide) >= 2 and not wide.isna().to_numpy().any()
+
+    def compute_mle_elo_from_ranks(
+        self,
+        results_per_task: pd.DataFrame,
+        SCALE: int | float = 400,
+        INIT_RATING: int | float = 1000,
+        calibration_framework: str | None = None,
+        calibration_elo: float | None = None,
+        max_iter: int = 10_000,
+        tol: float = 1e-12,
+    ) -> pd.Series:
+        """Bradley-Terry Elo computed from per-task ranks, without materialising battles.
+
+        The Bradley-Terry likelihood equations are ``W_i = sum_j n_ij * p_i/(p_i + p_j)``, so when
+        every pair of methods meets on every task -- a complete, balanced schedule -- the data
+        enters only through the per-method win totals, which :meth:`_rank_win_matrix` reads off the
+        ranks.
+
+        That makes the whole battle table unnecessary. The standard path builds
+        ``T * n_methods * (n_methods - 1) / 2`` rows before compressing them back down to an
+        ``n x n`` pair matrix; this reads the same information off an ``n``-vector. Cost falls from
+        quadratic-in-methods to linear, and peak memory stops tracking the battle count.
+        """
+        methods, win_matrix = self._rank_win_matrix(results_per_task=results_per_task)
+        elo = self._bradley_terry_from_win_totals(
+            wins=win_matrix.sum(axis=1),
+            n_tasks=win_matrix.shape[1],
+            SCALE=SCALE,
+            INIT_RATING=INIT_RATING,
+            max_iter=max_iter,
+            tol=tol,
+        )
+        out = pd.Series(elo, index=methods)
+        if calibration_framework is not None:
+            target = INIT_RATING if calibration_elo is None else float(calibration_elo)
+            out += target - out[calibration_framework]
+        return out.sort_values(ascending=False)
+
+    @staticmethod
+    def _bradley_terry_from_win_totals(
+        wins: np.ndarray,
+        n_tasks: int,
+        SCALE: int | float = 400,
+        INIT_RATING: int | float = 1000,
+        max_iter: int = 10_000,
+        tol: float = 1e-12,
+    ) -> np.ndarray:
+        """Maximise the Bradley-Terry likelihood by minorization-maximization.
+
+        The MM update ``p_i <- W_i / sum_j n_ij/(p_i + p_j)`` increases the likelihood at every
+        step and needs no gradients. Strengths are renormalised each iteration because the
+        likelihood only determines them up to a common factor.
+
+        That same indeterminacy means the ratings need a convention to pin them down; ratings are
+        centred so the field averages ``INIT_RATING``, which is where the battle path lands.
+        """
+        n = len(wins)
+        counts = np.full((n, n), float(n_tasks))
+        np.fill_diagonal(counts, 0.0)
+        p = np.ones(n) / n
+        for _ in range(max_iter):
+            denom = (counts / (p[:, None] + p[None, :] + np.eye(n))).sum(axis=1)
+            p_new = wins / denom
+            p_new /= p_new.sum()
+            if np.max(np.abs(p_new - p)) < tol:
+                p = p_new
+                break
+            p = p_new
+        log_p = np.log10(p)
+        return SCALE * (log_p - log_p.mean()) + INIT_RATING
 
     def compute_mle_elo(
         self,
@@ -441,6 +594,46 @@ class EloHelper:
             },
             show_process=show_process,
         )
+
+    def compute_elo_ratings_from_ranks(
+        self,
+        results_per_task: pd.DataFrame,
+        seed: int = 0,
+        calibration_framework=None,
+        calibration_elo=None,
+        INIT_RATING: float = 1000,
+        BOOTSTRAP_ROUNDS: int = 100,
+        SCALE: int = 400,
+        show_process: bool = True,
+    ) -> pd.DataFrame:
+        """Task-level bootstrap of :meth:`compute_mle_elo_from_ranks`, without materialising battles.
+
+        The bootstrap resamples tasks with replacement, which on the rank path is just a
+        multiplicity vector over the columns of :meth:`_rank_win_matrix`. Each round is then a
+        matrix-vector product plus one Bradley-Terry solve, so the battle table -- and the cost of
+        reweighting it every round -- drops out entirely.
+        """
+        methods, win_matrix = self._rank_win_matrix(results_per_task=results_per_task)
+        n_tasks = win_matrix.shape[1]
+
+        rng = np.random.default_rng(seed=seed)
+        rows = []
+        for _ in tqdm(range(BOOTSTRAP_ROUNDS), desc="bootstrap", disable=not show_process):
+            counts = np.bincount(rng.choice(n_tasks, size=n_tasks, replace=True), minlength=n_tasks)
+            elo = self._bradley_terry_from_win_totals(
+                wins=win_matrix @ counts.astype(float),
+                n_tasks=n_tasks,
+                SCALE=SCALE,
+                INIT_RATING=INIT_RATING,
+            )
+            ser = pd.Series(elo, index=methods)
+            if calibration_framework is not None:
+                target = INIT_RATING if calibration_elo is None else float(calibration_elo)
+                ser += target - ser[calibration_framework]
+            rows.append(ser)
+
+        df = pd.DataFrame(rows)
+        return df[df.median().sort_values(ascending=False).index]
 
     def compute_elo_rating_dataset_contributon(
         self,

--- a/packages/bencheval/src/bencheval/evaluator.py
+++ b/packages/bencheval/src/bencheval/evaluator.py
@@ -11,7 +11,7 @@ from ._analysis import DatasetAnalysisMixin
 from ._common import FRONTIER_ADVANTAGE, IMPROVABILITY, LOSS_RESCALED, RANK
 from ._plotting import PlottingMixin
 from ._validation import ResultsValidationMixin
-from .elo_utils import EloHelper
+from .elo_utils import EloHelper, use_fast_elo
 from .mean_utils import compute_weighted_mean_by_task
 from .winrate_utils import compute_winrate, compute_winrate_matrix
 
@@ -658,10 +658,14 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
         elo_helper = EloHelper(
             method_col=self.method_col, task_col=self.task_col, error_col=self.error_col, split_col=split_col
         )
-        battles = elo_helper.convert_results_to_battles(results_df=results_per_task)
+        # The rank path covers both the single fit and the bootstrap, so when it applies no battle
+        # table is built at all.
+        use_rank_path = use_fast_elo() and elo_helper.can_compute_elo_from_ranks(results_per_task)
+        needs_bootstrap = use_bootstrap_median or (include_quantiles and BOOTSTRAP_ROUNDS > 1)
 
-        can_compute_elo = len(battles) > 0
-        if not can_compute_elo:
+        battles = None if use_rank_path else elo_helper.convert_results_to_battles(results_df=results_per_task)
+
+        if not use_rank_path and len(battles) == 0:
             task_groupby_cols = [self.task_col]
             if split_col is not None:
                 task_groupby_cols.append(split_col)
@@ -695,9 +699,12 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
         bootstrap_median = None
         bootstrap_elo_lu = None
         bars_quantiles = None
-        if use_bootstrap_median or (include_quantiles and BOOTSTRAP_ROUNDS > 1):
-            bootstrap_elo_lu = elo_helper.compute_elo_ratings(
-                battles=battles,
+        if needs_bootstrap:
+            bootstrap_fn = (
+                elo_helper.compute_elo_ratings_from_ranks if use_rank_path else elo_helper.compute_elo_ratings
+            )
+            bootstrap_elo_lu = bootstrap_fn(
+                **({"results_per_task": results_per_task} if use_rank_path else {"battles": battles}),
                 calibration_framework=calibration_framework,
                 calibration_elo=calibration_elo,
                 INIT_RATING=INIT_RATING,
@@ -709,6 +716,14 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
 
         if use_bootstrap_median:
             elo = bootstrap_median
+        elif use_rank_path:
+            elo = elo_helper.compute_mle_elo_from_ranks(
+                results_per_task=results_per_task,
+                INIT_RATING=INIT_RATING,
+                SCALE=SCALE,
+                calibration_framework=calibration_framework,
+                calibration_elo=calibration_elo,
+            )
         else:
             elo = elo_helper.compute_mle_elo(
                 battles=battles,

--- a/tests/bencheval/test_elo_utils.py
+++ b/tests/bencheval/test_elo_utils.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 
+from bencheval import elo_utils
 from bencheval.elo_utils import EloHelper
 
 
@@ -154,3 +156,180 @@ def test_module_flag_and_env_var_are_independent(monkeypatch):
     monkeypatch.setattr(elo_utils, "USE_LEGACY_ELO_SOLVER_TOL", True)
     monkeypatch.setenv(elo_utils.LEGACY_ELO_SOLVER_TOL_ENV_VAR, "0")
     assert elo_utils.elo_solver_tol() == elo_utils.LEGACY_ELO_SOLVER_TOL
+
+
+def _ladder_results(n_methods: int = 10, n_tasks: int = 300, seed: int = 0) -> pd.DataFrame:
+    """A dense field with a genuine strength ladder, drawn so pairwise outcomes are logistic."""
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(seed)
+    strengths = np.linspace(3.0, -3.0, n_methods)
+    err = -(strengths[:, None] + rng.gumbel(size=(n_methods, n_tasks)))
+    return pd.DataFrame(
+        {
+            "method": np.repeat([f"m{i}" for i in range(n_methods)], n_tasks),
+            "task": np.tile([f"t{j}" for j in range(n_tasks)], n_methods),
+            "metric_error": err.ravel(),
+        }
+    )
+
+
+def test_elo_from_ranks_matches_the_battle_path():
+    """The shortcut and the battle path maximise the same likelihood, so they agree."""
+    import numpy as np
+
+    from bencheval.elo_utils import EloHelper
+    from bencheval.evaluator import BenchmarkEvaluator
+
+    df = _ladder_results()
+    evaluator = BenchmarkEvaluator(task_col="task", error_col="metric_error")
+    reference = evaluator.compute_elo(
+        results_per_task=df, BOOTSTRAP_ROUNDS=1, include_quantiles=False, round_decimals=None
+    )
+    reference = (reference["elo"] if hasattr(reference, "columns") else reference).astype(float)
+
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+    fast = helper.compute_mle_elo_from_ranks(results_per_task=df).reindex(reference.index)
+    # Bradley-Terry fixes ratings only up to a constant, so compare on a common anchor.
+    fast = fast - fast.mean() + reference.mean()
+
+    assert np.abs(fast - reference).max() < 0.05
+    assert list(fast.sort_values(ascending=False).index) == list(reference.sort_values(ascending=False).index)
+
+
+def test_elo_from_ranks_honours_the_calibration_anchor():
+    from bencheval.elo_utils import EloHelper
+
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+    out = helper.compute_mle_elo_from_ranks(
+        results_per_task=_ladder_results(), calibration_framework="m3", calibration_elo=1000
+    )
+    assert out["m3"] == pytest.approx(1000.0)
+
+
+def test_elo_from_ranks_rejects_a_missing_result():
+    """A gap in the schedule must raise, not quietly give a different answer.
+
+    Win totals are a sufficient statistic only when every pair meets on every task.
+    """
+    from bencheval.elo_utils import EloHelper
+
+    df = _ladder_results()
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+    with pytest.raises(ValueError, match="every method to have every task"):
+        helper.compute_mle_elo_from_ranks(results_per_task=df.iloc[:-1])
+
+
+def test_elo_from_ranks_orders_a_dominant_method_first():
+    """A method that wins nearly everything should top the table, ties averaged included."""
+    import numpy as np
+
+    from bencheval.elo_utils import EloHelper
+
+    df = _ladder_results(n_methods=5, n_tasks=200)
+    wide = df.pivot(index="method", columns="task", values="metric_error")
+    wide.loc["m0"] = wide.min(axis=0) - 1.0
+    wide.iloc[:, :10] = 0.0  # a block of exact ties, exercising average-rank credit
+    df = wide.stack().rename("metric_error").reset_index()
+
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+    out = helper.compute_mle_elo_from_ranks(results_per_task=df)
+    assert out.index[0] == "m0"
+    assert np.isfinite(out.to_numpy()).all()
+
+
+def _ragged_results(n_methods: int = 6, seed: int = 0) -> pd.DataFrame:
+    """Results over tasks whose split counts differ, which is where the weighting matters."""
+    rng = np.random.default_rng(seed)
+    skill = rng.normal(0, 1, n_methods)
+    rows = []
+    for task, n_splits in enumerate([1, 2, 5, 10, 3]):
+        for split in range(n_splits):
+            for i in range(n_methods):
+                rows.append((f"m{i}", f"task{task}", split, -skill[i] + rng.normal(0, 1)))
+    return pd.DataFrame(rows, columns=["method", "task", "split", "metric_error"])
+
+
+def _elo_helper(split_col: str | None = "split") -> EloHelper:
+    return EloHelper(method_col="method", task_col="task", error_col="metric_error", split_col=split_col)
+
+
+def test_rank_path_matches_the_battle_path_on_a_ragged_split_grid():
+    """Tasks contribute equally however many splits they ran, as the battle weights specify."""
+    results = _ragged_results()
+    helper = _elo_helper()
+
+    from_ranks = helper.compute_mle_elo_from_ranks(results_per_task=results, calibration_framework="m0")
+    battles = helper.convert_results_to_battles(results_df=results)
+    from_battles = helper.compute_mle_elo(battles=battles, calibration_framework="m0")
+
+    pd.testing.assert_series_equal(from_ranks, from_battles.reindex(from_ranks.index), atol=1e-2, rtol=0)
+
+
+def test_rank_path_matches_the_battle_path_without_splits():
+    results = _ragged_results().groupby(["method", "task"], as_index=False)["metric_error"].mean()
+    helper = _elo_helper(split_col=None)
+
+    from_ranks = helper.compute_mle_elo_from_ranks(results_per_task=results, calibration_framework="m0")
+    from_battles = helper.compute_mle_elo(
+        battles=helper.convert_results_to_battles(results_df=results), calibration_framework="m0"
+    )
+
+    pd.testing.assert_series_equal(from_ranks, from_battles.reindex(from_ranks.index), atol=1e-2, rtol=0)
+
+
+def test_rank_path_bootstrap_matches_the_battle_path():
+    results = _ragged_results()
+    helper = _elo_helper()
+
+    from_ranks = helper.compute_elo_ratings_from_ranks(
+        results_per_task=results, BOOTSTRAP_ROUNDS=25, show_process=False
+    )
+    from_battles = helper.compute_elo_ratings(
+        battles=helper.convert_results_to_battles(results_df=results), BOOTSTRAP_ROUNDS=25, show_process=False
+    )
+
+    assert from_ranks.shape == from_battles.shape
+    for quantile in (0.025, 0.5, 0.975):
+        a = from_ranks.quantile(quantile)
+        b = from_battles.quantile(quantile).reindex(a.index)
+        assert (a - b).abs().max() < 1e-2
+
+
+def test_ratings_are_centred_on_init_rating():
+    """Bradley-Terry fixes strengths only up to a common factor, so the offset needs a convention."""
+    elo = _elo_helper().compute_mle_elo_from_ranks(results_per_task=_ragged_results(), INIT_RATING=1000)
+    assert elo.mean() == pytest.approx(1000)
+
+
+def test_rank_path_rejects_an_incomplete_schedule():
+    results = _ragged_results()
+    helper = _elo_helper()
+
+    assert helper.can_compute_elo_from_ranks(results)
+    holey = results.drop(results.index[:1])
+    assert not helper.can_compute_elo_from_ranks(holey)
+    with pytest.raises(ValueError, match="complete and balanced"):
+        helper.compute_mle_elo_from_ranks(results_per_task=holey)
+
+
+def test_rank_path_rejects_duplicate_rows():
+    """The battle path raises on these; averaging them away instead would diverge silently."""
+    results = _ragged_results()
+    assert not _elo_helper().can_compute_elo_from_ranks(pd.concat([results, results.head(1)]))
+
+
+def test_fast_elo_is_on_by_default_and_off_under_the_legacy_flag(monkeypatch):
+    assert elo_utils.use_fast_elo()
+
+    monkeypatch.setattr(elo_utils, "USE_LEGACY_ELO_SOLVER_TOL", True)
+    assert not elo_utils.use_fast_elo(), "the legacy tolerance must reach the solver it names"
+    monkeypatch.setattr(elo_utils, "USE_LEGACY_ELO_SOLVER_TOL", False)
+
+    monkeypatch.setattr(elo_utils, "USE_FAST_ELO", False)
+    assert not elo_utils.use_fast_elo()
+    monkeypatch.setattr(elo_utils, "USE_FAST_ELO", True)
+
+    monkeypatch.setenv(elo_utils.DISABLE_FAST_ELO_ENV_VAR, "1")
+    assert not elo_utils.use_fast_elo()


### PR DESCRIPTION
## What

`compute_elo` no longer materialises a battle table. The Bradley-Terry likelihood equations are
`W_i = sum_j n_ij * p_i/(p_i + p_j)`, so on a complete balanced schedule the data enters only
through the per-method win totals — and a method's rank on a task is one plus the number of methods
that beat it, so those totals follow directly from the ranks. The old path built `T * n^2 / 2` rows
only to compress them back into an `n x n` pair matrix; this reads the same information off an
`n`-vector.

Both the single fit and the task-level bootstrap go through it: a bootstrap round is just a
multiplicity vector over the win matrix's columns, so each round is a matvec plus one solve.

## Results are unchanged

On the TabArena leaderboard (84 methods, 51 tasks, 816 task-splits), against the battle path:

| | |
|---|---|
| `elo`, `elo+`, `elo-` | max abs delta `0.000` at published precision (`2.5e-4` unrounded) |
| ranking | identical |
| `compare()` | **38.2s → 3.7s** (10.2x); Elo drops from 93% of that call to 27% |
| peak memory | no longer tracks the battle count (1.5 GB → 10 MB of Elo working set at 86x900) |

Larger synthetic fields, where the battle count grows quadratically: 54x at 86 methods x 900 tasks,
31x at 150 x 1000, both at 0 Elo delta.

## Weighting

Units are weighted by `1 / n_splits(task)` and summed within their task, matching the weight
`convert_results_to_battles` attaches to each battle. This matters: tasks differ in how many splits
they ran (1 to 10 here), and weighting the splits equally instead tilts ratings toward the tasks
with the most — worth up to 75 Elo and 16 leaderboard positions on the current field.

## When it is skipped

The battle table is built exactly as before when:

- the schedule is incomplete, or has duplicate rows — win totals are a sufficient statistic only
  when every pair meets on every task, so the shortcut would otherwise silently disagree;
- the legacy solver tolerance is requested (`USE_LEGACY_ELO_SOLVER_TOL` / the env var from #489),
  whose whole purpose is reproducing one specific solver's output;
- `USE_FAST_ELO = False` or `TABARENA_DISABLE_FAST_ELO=1`.

## Tests

Rank and battle paths are checked against each other on a ragged split grid and without splits, for
the single fit and the bootstrap quantiles, plus coverage for the incomplete-schedule and
duplicate-row fallbacks, the `INIT_RATING` centring convention, and each toggle.