### PR TITLE
Vectorize filter_to_valid_tasks instead of testing one row at a time

### DIFF
--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -94,21 +94,10 @@ def compare(
 
 
 def filter_to_valid_tasks(df_to_filter: pd.DataFrame, df_filter: pd.DataFrame) -> pd.DataFrame:
-    dataset_fold_map = df_filter.groupby("dataset")["fold"].apply(set)
-
-    def is_in(dataset: str, fold: int) -> bool:
-        return (dataset in dataset_fold_map.index) and (fold in dataset_fold_map.loc[dataset])
-
-    # filter `df_to_filter` to only the dataset, fold pairs that are present in `df_filter`
-    is_in_lst = [
-        is_in(dataset, fold)
-        for dataset, fold in zip(
-            df_to_filter["dataset"],
-            df_to_filter["fold"],
-            strict=False,
-        )
-    ]
-    return df_to_filter[is_in_lst]
+    """Keep the rows of ``df_to_filter`` whose (dataset, fold) pair appears in ``df_filter``."""
+    valid_tasks = pd.MultiIndex.from_frame(df_filter[["dataset", "fold"]].drop_duplicates())
+    tasks = pd.MultiIndex.from_frame(df_to_filter[["dataset", "fold"]])
+    return df_to_filter[tasks.isin(valid_tasks)]
 
 
 def prepare_data(


### PR DESCRIPTION
`filter_to_valid_tasks` tested membership one row at a time, calling a Python predicate that did a
`.loc` lookup into a Series of sets for every row — about 66k calls on a full `compare()`. Building
a `MultiIndex` over `(dataset, fold)` and using `isin` does the same test in a single pass.

**37x faster in isolation**: 164ms → 4.5ms at 66k rows. On `compare()` it is worth ~6% of the
compute-only path (2.92s → 2.75s); it was a larger share before the Elo work in #491, and is now
one of the bigger remaining non-plotting costs.

Output is unchanged: the full 84-method leaderboard is bit-identical, and the two edge cases the
loop handled — an empty filter, and a filter sharing no `(dataset, fold)` pair with the input —
both still return the same rows.