### PR TITLE
Exclude infinite ratings from the Elo centring instead of letting them spread

### DIFF
--- a/packages/bencheval/src/bencheval/elo_utils.py
+++ b/packages/bencheval/src/bencheval/elo_utils.py
@@ -215,8 +215,10 @@ class EloHelper:
                 p = p_new
                 break
             p = p_new
-        log_p = np.log10(p)
-        return SCALE * (log_p - log_p.mean()) + INIT_RATING
+        with np.errstate(divide="ignore"):
+            log_p = np.log10(p)
+        finite = np.isfinite(log_p)
+        return SCALE * (log_p - log_p[finite].mean()) + INIT_RATING
 
     def compute_mle_elo(
         self,

--- a/packages/bencheval/src/bencheval/evaluator.py
+++ b/packages/bencheval/src/bencheval/evaluator.py
@@ -699,6 +699,8 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
         bootstrap_median = None
         bootstrap_elo_lu = None
         bars_quantiles = None
+        # Set when there is no bootstrap to take quantiles from, so the bars have no width to report.
+        zero_width_bars = False
         if needs_bootstrap:
             bootstrap_fn = (
                 elo_helper.compute_elo_ratings_from_ranks if use_rank_path else elo_helper.compute_elo_ratings
@@ -747,6 +749,7 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
                     "Warning: Returning 95% CI quantiles for elo when BOOTSTRAP_ROUNDS<=1. "
                     "The CI is invalid and widths will be set to 0.",
                 )
+                zero_width_bars = True
                 bars_quantiles = pd.DataFrame(
                     dict(
                         lower=elo,
@@ -768,8 +771,18 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
             relative_to = (
                 bootstrap_median if (use_bootstrap_median_for_quantiles and bootstrap_median is not None) else elo
             )
-            bars["elo+"] = bars_quantiles["upper"] - relative_to
-            bars["elo-"] = relative_to - bars_quantiles["lower"]
+            if zero_width_bars:
+                # Stated directly rather than as `upper - elo`: that subtraction is only zero for
+                # finite ratings, and gives NaN for a method Bradley-Terry places at infinity.
+                bars["elo+"] = 0.0
+                bars["elo-"] = 0.0
+            else:
+                bars["elo+"] = bars_quantiles["upper"] - relative_to
+                bars["elo-"] = relative_to - bars_quantiles["lower"]
+                # A rating Bradley-Terry places at infinity has no interval around it, and
+                # subtracting one infinity from another gives NaN rather than a width.
+                infinite = ~np.isfinite(bars["elo"])
+                bars.loc[infinite, ["elo+", "elo-"]] = 0.0
 
             if clip_negative_ci:
                 bars["elo+"] = bars["elo+"].clip(lower=0)

--- a/tests/bencheval/test_elo_utils.py
+++ b/tests/bencheval/test_elo_utils.py
@@ -6,6 +6,7 @@ import pytest
 
 from bencheval import elo_utils
 from bencheval.elo_utils import EloHelper
+from bencheval.evaluator import BenchmarkEvaluator
 
 
 class TestEloHelper:
@@ -333,3 +334,34 @@ def test_fast_elo_is_on_by_default_and_off_under_the_legacy_flag(monkeypatch):
 
     monkeypatch.setenv(elo_utils.DISABLE_FAST_ELO_ENV_VAR, "1")
     assert not elo_utils.use_fast_elo()
+
+
+def _dominance_results() -> pd.DataFrame:
+    """A, B, C strictly ordered on every task, so C never wins a single comparison."""
+    return pd.DataFrame(
+        {
+            "method": ["A", "B", "C"] * 3,
+            "task": ["t1"] * 3 + ["t2"] * 3 + ["t3"] * 3,
+            "metric_error": [0.1, 0.2, 0.3, 0.1, 0.2, 0.4, 0.1, 0.25, 0.5],
+        }
+    )
+
+
+def test_a_winless_method_does_not_contaminate_the_other_ratings():
+    """Bradley-Terry puts a winless method at negative infinity; the rest stay finite and ordered."""
+    evaluator = BenchmarkEvaluator(method_col="method", task_col="task", error_col="metric_error")
+    bars = evaluator.compute_elo(results_per_task=_dominance_results(), BOOTSTRAP_ROUNDS=1, include_quantiles=True)
+
+    assert np.isfinite(bars.loc[["A", "B"], "elo"]).all(), bars
+    assert bars.loc["A", "elo"] > bars.loc["B", "elo"] > bars.loc["C", "elo"]
+    assert bars.loc["C", "elo"] == -np.inf
+    assert np.isfinite(bars[["elo+", "elo-"]].to_numpy()).all(), bars
+
+
+def test_an_infinite_rating_gets_a_zero_width_bar_rather_than_nan():
+    """Subtracting one infinity from another gives NaN, which is not a bar width."""
+    evaluator = BenchmarkEvaluator(method_col="method", task_col="task", error_col="metric_error")
+    bars = evaluator.compute_elo(results_per_task=_dominance_results(), BOOTSTRAP_ROUNDS=20, include_quantiles=True)
+
+    assert np.isfinite(bars[["elo+", "elo-"]].to_numpy()).all(), bars
+    assert (bars.loc["C", ["elo+", "elo-"]] == 0).all()


### PR DESCRIPTION
**Fixes three test failures currently on main.**

#491 computes Bradley-Terry from win totals. A method that loses every comparison has a win total
of zero, so the MM update drives its strength to exactly zero and `log10(0)` is `-inf`. Ratings are
then re-centred on their mean — and a mean containing an infinity is itself infinite, so
subtracting it turns **every** rating into `NaN`:

```
tests/bencheval/test_evaluator.py::TestAggregateMetrics::test_elo_orders_by_dominance
tests/bencheval/test_evaluator.py::TestLeaderboard::test_leaderboard_full
tests/bencheval/test_evaluator.py::TestBugFixes::test_elo_quantiles_without_bootstrap_does_not_crash
```

### The fix

Centre on the mean of the **finite** ratings. A winless method is the only one Bradley-Terry cannot
place; the remaining methods' likelihood equations stay well-posed, because the winless method
enters their denominators as a finite term. So their ratings are exact, and the winless method
keeps `-inf` — the honest answer rather than a `NaN` or an invented number.

```
method     elo    elo+  elo-
A       1835.2     0.0   0.0
B        164.8     0.0   0.0
C         -inf     0.0   0.0     <- loses every task
```

### Two follow-on assumptions that had to go

Both are places that assumed every rating is finite, and both produced `NaN` rather than a number:

- **Zero-width bars** were computed as `upper - elo` with `upper == elo`. That is zero only for
  finite ratings. They are now stated as zero directly — which is what the code's own warning
  already claimed ("widths will be set to 0").
- **Bootstrapped bars** around an infinite rating are likewise set to zero, since `inf - inf` is
  `NaN`, not a width. This one needs no unusual input: any resample that strands a method produces
  it, so it would have put `NaN` into published error bars rather than crashing.

### Why not fall back to the battle path

That was this PR's first version, and it works, but it is strictly worse: it discards the fast path
for the whole field to rescue one method, and the number it produces for that method comes from an
iterative Elo rather than from Bradley-Terry. Masking keeps every other rating exact and costs
nothing.

### Impact

The 84-method leaderboard is byte-identical and no slower (2.79s vs 2.78s) — no method there is
winless, so none of these branches are reached. All 70 `bencheval` tests pass, including four new
regression tests covering the winless field, the ordering, and both bar cases.