### PR TITLE
Score normalized error over whole columns instead of row by row

### DIFF
--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -241,19 +241,15 @@ class LeaderboardReporter:
             framework_col=method_col,
         )
 
-        df_results["normalized-error-task"] = [
-            normalized_scorer_task.rank(task=(dataset, fold), error=error)
-            for (dataset, fold, error) in zip(
-                df_results["dataset"], df_results["fold"], df_results[self.error_col], strict=False
-            )
-        ]
+        df_results["normalized-error-task"] = normalized_scorer_task.rank_many(
+            tasks=pd.MultiIndex.from_arrays([df_results["dataset"], df_results["fold"]]),
+            errors=df_results[self.error_col].to_numpy(),
+        )
 
-        df_results_per_dataset["normalized-error-dataset"] = [
-            normalized_scorer_dataset.rank(task=dataset, error=error)
-            for (dataset, error) in zip(
-                df_results_per_dataset["dataset"], df_results_per_dataset[self.error_col], strict=False
-            )
-        ]
+        df_results_per_dataset["normalized-error-dataset"] = normalized_scorer_dataset.rank_many(
+            tasks=pd.Index(df_results_per_dataset["dataset"]),
+            errors=df_results_per_dataset[self.error_col].to_numpy(),
+        )
 
         df_results_per_dataset = df_results_per_dataset.set_index(["dataset", method_col], drop=True)[
             "normalized-error-dataset"

--- a/packages/tabarena/src/tabarena/utils/normalized_scorer.py
+++ b/packages/tabarena/src/tabarena/utils/normalized_scorer.py
@@ -46,3 +46,15 @@ class NormalizedScorer:
         topline = self.topline_dict[task]
         res = (error - topline) / np.clip(baseline - topline, a_min=1e-5, a_max=None)
         return np.clip(res, 0, 1)
+
+    def rank_many(self, tasks: pd.Index, errors: np.ndarray) -> np.ndarray:
+        """:meth:`rank` over whole columns: one score per (task, error) pair.
+
+        `tasks` indexes the per-task baseline and topline, so it must carry one entry per error --
+        a `MultiIndex` when tasks are (dataset, fold) pairs. Scoring row by row instead spends most
+        of its time in `np.clip`'s dispatch for two scalars, which dwarfs the arithmetic.
+        """
+        baseline = tasks.map(self.baseline_dict).to_numpy(dtype=float)
+        topline = tasks.map(self.topline_dict).to_numpy(dtype=float)
+        res = (np.asarray(errors, dtype=float) - topline) / np.clip(baseline - topline, a_min=1e-5, a_max=None)
+        return np.clip(res, 0, 1)


### PR DESCRIPTION
`compute_normalized_error_dynamic` built `normalized-error-task` with a list comprehension calling
`NormalizedScorer.rank` once per row — **72,828 calls** on a full `compare()` — and repeated the
pattern for the per-dataset column.

The cost is not the arithmetic but the dispatch: each call clips two scalars, and scalar `np.clip`
goes through `_wrapfunc`/`_wrapit`. Those **145,656 clip calls were 0.37s of the 0.46s** the scoring
spent.

`rank_many` looks up baseline and topline once per column through the task index and clips the whole
array — the same computation in one pass. `rank` is unchanged for scalar use.

| | |
|---|---|
| scoring in isolation | **262ms → 31ms (9x)** at 72k rows |
| plot-free, bootstrap-free `compare()` | **1.03s → 0.82s** |
| output | both normalized-error columns bit-identical (`np.array_equal`, max abs delta 0.0) over all 66,528 rows |

Verified at both levels the scorer is used: the `(dataset, fold)` task index and the per-dataset
index. The 84-method leaderboard is byte-identical. 47 tests covering the leaderboard, reporter and
scorer pass.

This was the largest remaining non-plotting cost in a compute-only `compare()` after #491, #492 and
#493. What is left is dominated by `compute_winrate_matrix` (~0.36s, already vectorized) and parquet
I/O.