### PR TITLE
Look up normalized-error baselines by index code rather than by dict

### DIFF
--- a/packages/tabarena/src/tabarena/utils/normalized_scorer.py
+++ b/packages/tabarena/src/tabarena/utils/normalized_scorer.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
-
-if TYPE_CHECKING:
-    import pandas as pd
+import pandas as pd
 
 
 class NormalizedScorer:
@@ -40,6 +36,13 @@ class NormalizedScorer:
         else:
             self.baseline_dict = df_results.groupby(task_col)[metric_error_col].median(numeric_only=True).to_dict()
 
+        # The same values again, as arrays behind a lookup index. `rank_many` then resolves a whole
+        # column with one hash of the task keys, rather than hashing a tuple per row through a dict.
+        keys = list(self.topline_dict)
+        self._task_keys = pd.MultiIndex.from_tuples(keys) if keys and isinstance(keys[0], tuple) else pd.Index(keys)
+        self._topline_values = np.array([self.topline_dict[key] for key in keys], dtype=float)
+        self._baseline_values = np.array([self.baseline_dict.get(key, np.nan) for key in keys], dtype=float)
+
     # TODO rename to score, create parent class
     def rank(self, task: str, error: float) -> float:
         baseline = self.baseline_dict[task]
@@ -54,7 +57,12 @@ class NormalizedScorer:
         a `MultiIndex` when tasks are (dataset, fold) pairs. Scoring row by row instead spends most
         of its time in `np.clip`'s dispatch for two scalars, which dwarfs the arithmetic.
         """
-        baseline = tasks.map(self.baseline_dict).to_numpy(dtype=float)
-        topline = tasks.map(self.topline_dict).to_numpy(dtype=float)
+        codes = self._task_keys.get_indexer(tasks)
+        unknown = codes == -1
+        baseline = self._baseline_values[np.where(unknown, 0, codes)]
+        topline = self._topline_values[np.where(unknown, 0, codes)]
+
         res = (np.asarray(errors, dtype=float) - topline) / np.clip(baseline - topline, a_min=1e-5, a_max=None)
-        return np.clip(res, 0, 1)
+        scores = np.clip(res, 0, 1)
+        # A task the scorer never saw has no baseline to score against.
+        return np.where(unknown, np.nan, scores)

--- a/tests/tabarena/metrics/test_normalized_scorer.py
+++ b/tests/tabarena/metrics/test_normalized_scorer.py
@@ -40,3 +40,55 @@ def test_normalized_scorer():
     for query, expected in query_expected:
         print(scorer.rank("dataset1", query))
         assert np.isclose(scorer.rank("dataset1", query), expected)
+
+
+def _scorer() -> NormalizedScorer:
+    return NormalizedScorer(
+        df_results_by_dataset,
+        tasks=list(df_results_by_dataset[dataset_col].unique()),
+        baseline=None,
+        metric_error_col=metric_col,
+        task_col=dataset_col,
+        framework_col=framework_col,
+    )
+
+
+def test_rank_many_matches_rank_element_for_element():
+    scorer = _scorer()
+    tasks = pd.Index(df_results_by_dataset[dataset_col])
+    errors = df_results_by_dataset[metric_col].to_numpy()
+
+    scalar = np.array([scorer.rank(task=task, error=error) for task, error in zip(tasks, errors, strict=False)])
+
+    assert np.array_equal(scorer.rank_many(tasks=tasks, errors=errors), scalar)
+
+
+def test_rank_many_returns_nan_for_a_task_the_scorer_never_saw():
+    """`get_indexer` reports -1 for an absent key, which would otherwise index from the array's end."""
+    scorer = _scorer()
+    tasks = pd.Index(["dataset1", "never-seen", "dataset2"])
+
+    scores = scorer.rank_many(tasks=tasks, errors=np.array([1.0, 1.0, 10.0]))
+
+    assert np.isnan(scores[1])
+    assert not np.isnan(scores[[0, 2]]).any()
+
+
+def test_rank_many_handles_a_multiindex_task_key():
+    df = df_results_by_dataset.assign(fold=[0, 0, 0, 1, 1, 1])
+    scorer = NormalizedScorer(
+        df,
+        tasks=[tuple(task) for task in df[[dataset_col, "fold"]].drop_duplicates().to_numpy().tolist()],
+        baseline=None,
+        metric_error_col=metric_col,
+        task_col=[dataset_col, "fold"],
+        framework_col=framework_col,
+    )
+    tasks = pd.MultiIndex.from_arrays([df[dataset_col], df["fold"]])
+
+    scores = scorer.rank_many(tasks=tasks, errors=df[metric_col].to_numpy())
+
+    expected = np.array(
+        [scorer.rank(task=task, error=error) for task, error in zip(tasks, df[metric_col], strict=False)]
+    )
+    assert np.array_equal(scores, expected)


### PR DESCRIPTION
`rank_many` (added in #496) resolved each row's baseline and topline with `MultiIndex.map(dict)`.
That materializes a tuple per row and hashes it — **0.064s of a `compare()` in `MultiIndex._values`
alone**, and the largest remaining self-time entry after #496, #497 and #498.

`NormalizedScorer` now also keeps those precomputed values as arrays behind a lookup index, so a
whole column resolves with a single `get_indexer` call instead of a per-row dict hash. The values
are the same ones as before — this changes how they are looked up, not what they are, so the
scorer's contract (baselines come from the frame it was built on) is untouched, and `rank()` is
unchanged.

| | |
|---|---|
| baseline lookup | **9.5ms → 0.5ms (19x)** at 66k rows |
| plot-free, bootstrap-free `compare()` | **0.57s → 0.49s** (measured on main incl. #498) |

### Correctness

Bit-identical (`np.array_equal`) against the previous implementation at both levels the scorer is
used — the `(dataset, fold)` task index over all 66,528 rows, and the per-dataset index — and the
84-method leaderboard is unchanged.

One trap worth naming: `get_indexer` returns `-1` for a key it does not hold, and `-1` indexes from
the *end* of a numpy array, so an unknown task would silently pick up some other task's baseline.
Those rows are masked back to `NaN`, which is what `map` returned for them.

Three tests added: `rank_many` against `rank` element for element, the unknown-task `NaN`, and the
`MultiIndex` task key.