### PR TITLE
Solve Bradley-Terry with L-BFGS instead of the MM iteration

### DIFF
--- a/packages/bencheval/src/bencheval/elo_utils.py
+++ b/packages/bencheval/src/bencheval/elo_utils.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
+from scipy.optimize import minimize
 from sklearn.linear_model import LogisticRegression
 from tqdm import tqdm
 
@@ -48,6 +49,13 @@ def elo_solver_tol() -> float:
     """The lbfgs tolerance for the Elo fit, honouring :func:`use_legacy_elo_solver_tol`."""
     return LEGACY_ELO_SOLVER_TOL if use_legacy_elo_solver_tol() else ELO_SOLVER_TOL
 
+
+#: Ridge on the log-strengths, matching the L2 penalty `compute_mle_elo`'s `LogisticRegression`
+#: applies at `C=1e6`. sklearn penalises `beta = t / ln(10)` and scales the likelihood by `C`, so
+#: `0.5 * ||beta||^2` becomes this coefficient on `||t||^2`. Negligible on a real field (4e-6 Elo),
+#: it is what pins down a *separable* one, where the unpenalised maximum runs off to infinity and
+#: any answer would otherwise depend on where the solver's tolerance happened to stop it.
+BT_RIDGE = 0.5 / (1e6 * math.log(10) ** 2)
 
 #: Env var equivalent of :data:`USE_FAST_ELO`, for turning the rank path off without touching code.
 DISABLE_FAST_ELO_ENV_VAR = "TABARENA_DISABLE_FAST_ELO"
@@ -186,7 +194,7 @@ class EloHelper:
         return out.sort_values(ascending=False)
 
     @staticmethod
-    def _bradley_terry_from_win_totals(
+    def _bradley_terry_by_mm(
         wins: np.ndarray,
         n_tasks: int,
         SCALE: int | float = 400,
@@ -196,12 +204,11 @@ class EloHelper:
     ) -> np.ndarray:
         """Maximise the Bradley-Terry likelihood by minorization-maximization.
 
-        The MM update ``p_i <- W_i / sum_j n_ij/(p_i + p_j)`` increases the likelihood at every
-        step and needs no gradients. Strengths are renormalised each iteration because the
-        likelihood only determines them up to a common factor.
-
-        That same indeterminacy means the ratings need a convention to pin them down; ratings are
-        centred so the field averages ``INIT_RATING``, which is where the battle path lands.
+        The update ``p_i <- W_i / sum_j n_ij/(p_i + p_j)`` increases the likelihood at every step and
+        needs no gradients. It is slow to converge, but it is exact on a winless method: that
+        method's strength updates to 0 and stays there, giving the negative-infinite rating the
+        likelihood actually implies. Infinities are excluded from the centring so they do not spread
+        to the methods that do have a finite rating.
         """
         n = len(wins)
         counts = np.full((n, n), float(n_tasks))
@@ -219,6 +226,71 @@ class EloHelper:
             log_p = np.log10(p)
         finite = np.isfinite(log_p)
         return SCALE * (log_p - log_p[finite].mean()) + INIT_RATING
+
+    @staticmethod
+    def _bradley_terry_from_win_totals(
+        wins: np.ndarray,
+        n_tasks: int,
+        SCALE: int | float = 400,
+        INIT_RATING: int | float = 1000,
+        max_iter: int = 10_000,
+        tol: float = 1e-12,
+        init: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Maximise the Bradley-Terry likelihood, working in log-strengths.
+
+        With every pair meeting ``n_tasks`` times, the log-likelihood is
+        ``sum_i W_i t_i - n_tasks * sum_{i<j} log(e^{t_i} + e^{t_j})`` -- concave in ``t``, and
+        expressible from the win totals alone. L-BFGS reaches its maximum in around 15 iterations
+        where the classic MM update needs several hundred, because MM's guaranteed ascent is
+        first-order and slows near the optimum.
+
+        The fit carries the same ridge as the battle path (:data:`BT_RIDGE`), which costs nothing on
+        a real field but pins down a separable one, where the unpenalised maximum is at infinity.
+        The likelihood fixes strengths only up to a common factor, so ratings are centred to average
+        ``INIT_RATING`` -- the convention the battle path lands on. ``init`` warm-starts the search,
+        which is worth roughly a third of the iterations when solving many bootstrap resamples.
+
+        A method that won nothing has no finite rating; that case is handed to
+        :meth:`_bradley_terry_by_mm`, which reaches the limit exactly.
+        """
+        if not np.all(wins > 0):
+            # A winless method's maximum is at negative infinity. MM reaches that limit exactly --
+            # its strength updates to 0 and stays there -- where a gradient step only ever walks
+            # toward it, so the degenerate case keeps the slower solver.
+            return EloHelper._bradley_terry_by_mm(
+                wins=wins,
+                n_tasks=n_tasks,
+                SCALE=SCALE,
+                INIT_RATING=INIT_RATING,
+                max_iter=max_iter,
+                tol=tol,
+            )
+
+        n = len(wins)
+        off_diagonal = ~np.eye(n, dtype=bool)
+        upper = np.triu_indices(n, 1)
+
+        def penalised_negative_log_likelihood(t: np.ndarray) -> tuple[float, np.ndarray]:
+            # log(e^{t_i} + e^{t_j}), shifted by the larger exponent so neither term overflows.
+            largest = np.maximum(t[:, None], t[None, :])
+            log_sum = largest + np.log(np.exp(t[:, None] - largest) + np.exp(t[None, :] - largest))
+            log_likelihood = wins @ t - n_tasks * log_sum[upper].sum()
+            win_probability = np.exp(t[:, None] - log_sum)
+            gradient = wins - n_tasks * np.where(off_diagonal, win_probability, 0.0).sum(axis=1)
+            # The ridge also removes the likelihood's flat direction, so no re-centring is needed
+            # to make the search well posed.
+            return -log_likelihood + BT_RIDGE * (t @ t), -gradient + 2 * BT_RIDGE * t
+
+        result = minimize(
+            penalised_negative_log_likelihood,
+            np.zeros(n) if init is None else np.asarray(init, dtype=float),
+            jac=True,
+            method="L-BFGS-B",
+            options={"maxiter": max_iter, "ftol": tol * 1e-3, "gtol": tol},
+        )
+        log_strength = result.x - result.x.mean()
+        return SCALE * (log_strength / np.log(10)) + INIT_RATING
 
     def compute_mle_elo(
         self,

--- a/tests/bencheval/test_elo_utils.py
+++ b/tests/bencheval/test_elo_utils.py
@@ -365,3 +365,107 @@ def test_an_infinite_rating_gets_a_zero_width_bar_rather_than_nan():
 
     assert np.isfinite(bars[["elo+", "elo-"]].to_numpy()).all(), bars
     assert (bars.loc["C", ["elo+", "elo-"]] == 0).all()
+
+
+def _tournament_win_totals(n_methods: int, n_tasks: int, rng: np.random.Generator) -> np.ndarray:
+    """Win totals from an actual tournament, which arbitrary vectors are not.
+
+    Bradley-Terry has no finite maximum for win totals no tournament could produce, so a solver
+    comparison over made-up vectors compares two kinds of divergence rather than two answers.
+    """
+    errors = rng.normal(size=(n_methods, n_tasks)) - rng.normal(0, 1, n_methods)[:, None]
+    ranks = pd.DataFrame(errors).rank(axis=0, method="average").to_numpy()
+    return (n_methods - ranks).sum(axis=1)
+
+
+def _log_likelihood(elo: np.ndarray, wins: np.ndarray, n_tasks: int) -> float:
+    strengths = (np.asarray(elo) - 1000) / 400 * np.log(10)
+    largest = np.maximum(strengths[:, None], strengths[None, :])
+    log_sum = largest + np.log(np.exp(strengths[:, None] - largest) + np.exp(strengths[None, :] - largest))
+    return wins @ strengths - n_tasks * log_sum[np.triu_indices(len(strengths), 1)].sum()
+
+
+def test_lbfgs_never_lands_below_mm_on_the_likelihood():
+    """The contract for swapping solvers: never a worse fit, whatever the field looks like.
+
+    Ratings can differ a lot on a near-separable field, where the maximum is extreme and MM is still
+    crawling toward it at its iteration cap -- so the likelihood, not the ratings, is what to assert.
+    """
+    rng = np.random.default_rng(0)
+    checked = 0
+    for _ in range(50):
+        n_methods, n_tasks = int(rng.integers(3, 15)), int(rng.integers(5, 30))
+        wins = _tournament_win_totals(n_methods, n_tasks, rng)
+        if not np.all(wins > 0):
+            continue
+        checked += 1
+        by_mm = EloHelper._bradley_terry_by_mm(wins=wins, n_tasks=n_tasks)
+        by_lbfgs = EloHelper._bradley_terry_from_win_totals(wins=wins, n_tasks=n_tasks)
+        assert _log_likelihood(by_lbfgs, wins, n_tasks) >= _log_likelihood(by_mm, wins, n_tasks) - 1e-9
+    assert checked > 20, checked
+
+
+def test_the_two_solvers_agree_on_a_well_conditioned_field():
+    """Where the maximum is comfortably interior, both solvers reach it and the ratings match."""
+    rng = np.random.default_rng(0)
+    checked = 0
+    for _ in range(50):
+        n_methods, n_tasks = int(rng.integers(4, 15)), int(rng.integers(15, 30))
+        wins = _tournament_win_totals(n_methods, n_tasks, rng)
+        # Skip near-separable fields: a method winning almost nothing pushes the maximum so far out
+        # that MM stops at its iteration cap rather than at the optimum.
+        if wins.min() < 0.1 * n_tasks * (n_methods - 1):
+            continue
+        checked += 1
+        by_mm = EloHelper._bradley_terry_by_mm(wins=wins, n_tasks=n_tasks)
+        by_lbfgs = EloHelper._bradley_terry_from_win_totals(wins=wins, n_tasks=n_tasks)
+        assert np.abs(by_mm - by_lbfgs).max() < 1e-2
+    assert checked > 5, checked
+
+
+def test_a_winless_method_keeps_the_mm_solver():
+    """Its maximum is at negative infinity: MM reaches that limit, a gradient step only approaches it."""
+    rng = np.random.default_rng(0)
+    checked = 0
+    for _ in range(200):
+        n_methods, n_tasks = int(rng.integers(3, 10)), int(rng.integers(2, 6))
+        wins = _tournament_win_totals(n_methods, n_tasks, rng)
+        if np.all(wins > 0):
+            continue
+        checked += 1
+        by_mm = EloHelper._bradley_terry_by_mm(wins=wins, n_tasks=n_tasks)
+        dispatched = EloHelper._bradley_terry_from_win_totals(wins=wins, n_tasks=n_tasks)
+        assert np.array_equal(by_mm, dispatched, equal_nan=True)
+        assert np.isneginf(dispatched[wins == 0]).all()
+    assert checked > 0, "no winless field was generated, so nothing was tested"
+
+
+def test_a_separable_field_lands_where_the_battle_path_does():
+    """{A,B} always beat {C,D}, so the unpenalised maximum is at infinity and no method is winless.
+
+    Without the ridge the answer is whatever the solver's tolerance happened to allow, which is how
+    MM and an unpenalised gradient step end up hundreds of Elo apart on the same data.
+    """
+    rows = []
+    for task in range(4):
+        strong = [0.1, 0.2] if task % 2 == 0 else [0.2, 0.1]
+        weak = [0.5, 0.6] if task % 2 == 0 else [0.6, 0.5]
+        rows += [
+            ("A", f"t{task}", strong[0]),
+            ("B", f"t{task}", strong[1]),
+            ("C", f"t{task}", weak[0]),
+            ("D", f"t{task}", weak[1]),
+        ]
+    results = pd.DataFrame(rows, columns=["method", "task", "metric_error"])
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+
+    methods, win_matrix = helper._rank_win_matrix(results_per_task=results)
+    wins = win_matrix.sum(axis=1)
+    assert (wins > 0).all(), "this field is separable but has no winless method"
+
+    from_ranks = pd.Series(
+        EloHelper._bradley_terry_from_win_totals(wins=wins, n_tasks=win_matrix.shape[1]), index=methods
+    )
+    from_battles = helper.compute_mle_elo(battles=helper.convert_results_to_battles(results_df=results))
+
+    assert (from_ranks - from_battles.reindex(methods)).abs().max() < 1.0


### PR DESCRIPTION
The Elo bootstrap is **1.12s of a 1.60s plot-free `compare()` — 70% of it** — now that the rest of
the path has been trimmed. Nearly all of that is the minorization-maximization loop: on the current
field a single bootstrap round takes **259-591 MM iterations** (median 363).

With every pair meeting `n_tasks` times, the log-likelihood is
`sum_i W_i t_i - n_tasks * sum_{i<j} log(e^{t_i} + e^{t_j})` — concave in the log-strengths, and
expressible from the win totals the rank path already computes. L-BFGS reaches its maximum in about
**15** iterations, because MM's guaranteed ascent is first-order and crawls near the optimum.

| | |
|---|---|
| Elo bootstrap (200 rounds) | **1.10s → 0.32s (3.5x)** |
| default plot-free `compare()` | **1.60s → 0.81s (2.0x)** |
| leaderboard | byte-identical, ordering identical |

Agreement on the real field: **6.7e-06 Elo** on the single fit, **7.3e-05** per bootstrap round, and
at most **5.2e-05** on the 2.5% / 50% / 97.5% quantiles.

### It is also the better-converged solver

Over 50 random tournaments L-BFGS lands at least as high on the likelihood **every time**. On two
near-separable fields MM stopped at its 10,000-iteration cap more than **1000 Elo** short of the
maximum — the large rating gaps in those cases are MM being wrong, not L-BFGS.

### Degenerate fields

Two kinds, handled differently, because they are genuinely different problems.

**Separable** — one group of methods beats another on every task, no method winless. The
unpenalised maximum is at infinity, so the ratings reported are an artifact of wherever each
solver's tolerance stopped it, and the solvers disagree wildly:

| | A, B | C, D |
|---|---|---|
| battle path | 2347.26 | -347.26 |
| MM (current fast path) | 1936.25 | 63.75 |
| unpenalised L-BFGS | 3607.39 | -1607.39 |
| **this PR** | **2347.56** | **-347.56** |

The fix is to carry the same ridge the battle path's `LogisticRegression` already applies at
`C=1e6`: sklearn penalises `beta = t / ln(10)` and scales the likelihood by `C`, so `0.5*||beta||^2`
maps to a known coefficient on `||t||^2`. That makes the objective strictly convex — a unique answer
that does not depend on solver tolerances — and lands within **0.3 Elo** of the battle path. It is
worth 4e-6 Elo on a real field.

Note this case has **no winless method**, so a winless check does not catch it, and win totals alone
cannot detect separability.

**Winless** — a method that won nothing. Its maximum is at negative infinity; MM reaches that limit
exactly (the strength updates to 0 and stays) where a gradient step only approaches it. Those fields
are dispatched to MM, reproducing current `main` exactly: `0.000e+00` over 200 random winless fields.

For completeness: on a *fully* separable field the battle path abandons Bradley-Terry entirely
(`"only one class present after aggregation"`) and falls back to an iterative Elo, so no choice of
solver or penalty reproduces it. No real field hits any of these.

Tests cover the likelihood contract, agreement on well-conditioned fields, the separable case
against the battle path, and the winless dispatch.