### PR TITLE
Let the ridge handle winless methods too, so every Elo is finite

### DIFF
--- a/packages/bencheval/src/bencheval/elo_utils.py
+++ b/packages/bencheval/src/bencheval/elo_utils.py
@@ -194,40 +194,6 @@ class EloHelper:
         return out.sort_values(ascending=False)
 
     @staticmethod
-    def _bradley_terry_by_mm(
-        wins: np.ndarray,
-        n_tasks: int,
-        SCALE: int | float = 400,
-        INIT_RATING: int | float = 1000,
-        max_iter: int = 10_000,
-        tol: float = 1e-12,
-    ) -> np.ndarray:
-        """Maximise the Bradley-Terry likelihood by minorization-maximization.
-
-        The update ``p_i <- W_i / sum_j n_ij/(p_i + p_j)`` increases the likelihood at every step and
-        needs no gradients. It is slow to converge, but it is exact on a winless method: that
-        method's strength updates to 0 and stays there, giving the negative-infinite rating the
-        likelihood actually implies. Infinities are excluded from the centring so they do not spread
-        to the methods that do have a finite rating.
-        """
-        n = len(wins)
-        counts = np.full((n, n), float(n_tasks))
-        np.fill_diagonal(counts, 0.0)
-        p = np.ones(n) / n
-        for _ in range(max_iter):
-            denom = (counts / (p[:, None] + p[None, :] + np.eye(n))).sum(axis=1)
-            p_new = wins / denom
-            p_new /= p_new.sum()
-            if np.max(np.abs(p_new - p)) < tol:
-                p = p_new
-                break
-            p = p_new
-        with np.errstate(divide="ignore"):
-            log_p = np.log10(p)
-        finite = np.isfinite(log_p)
-        return SCALE * (log_p - log_p[finite].mean()) + INIT_RATING
-
-    @staticmethod
     def _bradley_terry_from_win_totals(
         wins: np.ndarray,
         n_tasks: int,
@@ -245,28 +211,17 @@ class EloHelper:
         where the classic MM update needs several hundred, because MM's guaranteed ascent is
         first-order and slows near the optimum.
 
-        The fit carries the same ridge as the battle path (:data:`BT_RIDGE`), which costs nothing on
-        a real field but pins down a separable one, where the unpenalised maximum is at infinity.
+        The fit carries the same ridge as the battle path (:data:`BT_RIDGE`). It costs 4e-6 Elo on a
+        real field, and it is what makes a *degenerate* one answerable at all: where a group of
+        methods beats another on every task, or a method wins nothing, the unpenalised maximum runs
+        off to infinity and the ratings would otherwise be an artifact of wherever the solver's
+        tolerance stopped. Every rating therefore comes back finite, as the battle path's penalty has
+        always made them.
+
         The likelihood fixes strengths only up to a common factor, so ratings are centred to average
         ``INIT_RATING`` -- the convention the battle path lands on. ``init`` warm-starts the search,
         which is worth roughly a third of the iterations when solving many bootstrap resamples.
-
-        A method that won nothing has no finite rating; that case is handed to
-        :meth:`_bradley_terry_by_mm`, which reaches the limit exactly.
         """
-        if not np.all(wins > 0):
-            # A winless method's maximum is at negative infinity. MM reaches that limit exactly --
-            # its strength updates to 0 and stays there -- where a gradient step only ever walks
-            # toward it, so the degenerate case keeps the slower solver.
-            return EloHelper._bradley_terry_by_mm(
-                wins=wins,
-                n_tasks=n_tasks,
-                SCALE=SCALE,
-                INIT_RATING=INIT_RATING,
-                max_iter=max_iter,
-                tol=tol,
-            )
-
         n = len(wins)
         off_diagonal = ~np.eye(n, dtype=bool)
         upper = np.triu_indices(n, 1)

--- a/packages/bencheval/src/bencheval/evaluator.py
+++ b/packages/bencheval/src/bencheval/evaluator.py
@@ -784,10 +784,6 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
             else:
                 bars["elo+"] = bars_quantiles["upper"] - relative_to
                 bars["elo-"] = relative_to - bars_quantiles["lower"]
-                # A rating Bradley-Terry places at infinity has no interval around it, and
-                # subtracting one infinity from another gives NaN rather than a width.
-                infinite = ~np.isfinite(bars["elo"])
-                bars.loc[infinite, ["elo+", "elo-"]] = 0.0
 
             if clip_negative_ci:
                 bars["elo+"] = bars["elo+"].clip(lower=0)

--- a/tests/bencheval/test_elo_utils.py
+++ b/tests/bencheval/test_elo_utils.py
@@ -347,24 +347,22 @@ def _dominance_results() -> pd.DataFrame:
     )
 
 
-def test_a_winless_method_does_not_contaminate_the_other_ratings():
-    """Bradley-Terry puts a winless method at negative infinity; the rest stay finite and ordered."""
+def test_a_winless_method_still_gets_a_finite_rating():
+    """The unpenalised likelihood puts it at negative infinity; the ridge is what stops it there."""
     evaluator = BenchmarkEvaluator(method_col="method", task_col="task", error_col="metric_error")
     bars = evaluator.compute_elo(results_per_task=_dominance_results(), BOOTSTRAP_ROUNDS=1, include_quantiles=True)
 
-    assert np.isfinite(bars.loc[["A", "B"], "elo"]).all(), bars
+    assert np.isfinite(bars["elo"].to_numpy()).all(), bars
     assert bars.loc["A", "elo"] > bars.loc["B", "elo"] > bars.loc["C", "elo"]
-    assert bars.loc["C", "elo"] == -np.inf
     assert np.isfinite(bars[["elo+", "elo-"]].to_numpy()).all(), bars
 
 
-def test_an_infinite_rating_gets_a_zero_width_bar_rather_than_nan():
-    """Subtracting one infinity from another gives NaN, which is not a bar width."""
+def test_a_bootstrapped_winless_field_produces_finite_bars():
+    """Every round is finite, so the quantiles subtract cleanly instead of giving inf - inf."""
     evaluator = BenchmarkEvaluator(method_col="method", task_col="task", error_col="metric_error")
     bars = evaluator.compute_elo(results_per_task=_dominance_results(), BOOTSTRAP_ROUNDS=20, include_quantiles=True)
 
-    assert np.isfinite(bars[["elo+", "elo-"]].to_numpy()).all(), bars
-    assert (bars.loc["C", ["elo+", "elo-"]] == 0).all()
+    assert np.isfinite(bars.to_numpy()).all(), bars
 
 
 def _tournament_win_totals(n_methods: int, n_tasks: int, rng: np.random.Generator) -> np.ndarray:
@@ -385,59 +383,31 @@ def _log_likelihood(elo: np.ndarray, wins: np.ndarray, n_tasks: int) -> float:
     return wins @ strengths - n_tasks * log_sum[np.triu_indices(len(strengths), 1)].sum()
 
 
-def test_lbfgs_never_lands_below_mm_on_the_likelihood():
-    """The contract for swapping solvers: never a worse fit, whatever the field looks like.
+def test_a_winless_field_lands_where_the_battle_path_does():
+    """C never wins, but the other pairs are mixed, so the battle path really does fit Bradley-Terry."""
+    errors = {
+        "A": [0.1, 0.4, 0.2, 0.3],
+        "B": [0.2, 0.1, 0.4, 0.15],
+        "D": [0.3, 0.2, 0.1, 0.35],
+        "C": [9.0, 9.0, 9.0, 9.0],
+    }
+    results = pd.DataFrame(
+        [(method, f"t{i}", error) for method, errs in errors.items() for i, error in enumerate(errs)],
+        columns=["method", "task", "metric_error"],
+    )
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
 
-    Ratings can differ a lot on a near-separable field, where the maximum is extreme and MM is still
-    crawling toward it at its iteration cap -- so the likelihood, not the ratings, is what to assert.
-    """
-    rng = np.random.default_rng(0)
-    checked = 0
-    for _ in range(50):
-        n_methods, n_tasks = int(rng.integers(3, 15)), int(rng.integers(5, 30))
-        wins = _tournament_win_totals(n_methods, n_tasks, rng)
-        if not np.all(wins > 0):
-            continue
-        checked += 1
-        by_mm = EloHelper._bradley_terry_by_mm(wins=wins, n_tasks=n_tasks)
-        by_lbfgs = EloHelper._bradley_terry_from_win_totals(wins=wins, n_tasks=n_tasks)
-        assert _log_likelihood(by_lbfgs, wins, n_tasks) >= _log_likelihood(by_mm, wins, n_tasks) - 1e-9
-    assert checked > 20, checked
+    methods, win_matrix = helper._rank_win_matrix(results_per_task=results)
+    wins = win_matrix.sum(axis=1)
+    assert (wins == 0).any(), "this field is supposed to contain a winless method"
 
+    from_ranks = pd.Series(
+        EloHelper._bradley_terry_from_win_totals(wins=wins, n_tasks=win_matrix.shape[1]), index=methods
+    )
+    from_battles = helper.compute_mle_elo(battles=helper.convert_results_to_battles(results_df=results))
 
-def test_the_two_solvers_agree_on_a_well_conditioned_field():
-    """Where the maximum is comfortably interior, both solvers reach it and the ratings match."""
-    rng = np.random.default_rng(0)
-    checked = 0
-    for _ in range(50):
-        n_methods, n_tasks = int(rng.integers(4, 15)), int(rng.integers(15, 30))
-        wins = _tournament_win_totals(n_methods, n_tasks, rng)
-        # Skip near-separable fields: a method winning almost nothing pushes the maximum so far out
-        # that MM stops at its iteration cap rather than at the optimum.
-        if wins.min() < 0.1 * n_tasks * (n_methods - 1):
-            continue
-        checked += 1
-        by_mm = EloHelper._bradley_terry_by_mm(wins=wins, n_tasks=n_tasks)
-        by_lbfgs = EloHelper._bradley_terry_from_win_totals(wins=wins, n_tasks=n_tasks)
-        assert np.abs(by_mm - by_lbfgs).max() < 1e-2
-    assert checked > 5, checked
-
-
-def test_a_winless_method_keeps_the_mm_solver():
-    """Its maximum is at negative infinity: MM reaches that limit, a gradient step only approaches it."""
-    rng = np.random.default_rng(0)
-    checked = 0
-    for _ in range(200):
-        n_methods, n_tasks = int(rng.integers(3, 10)), int(rng.integers(2, 6))
-        wins = _tournament_win_totals(n_methods, n_tasks, rng)
-        if np.all(wins > 0):
-            continue
-        checked += 1
-        by_mm = EloHelper._bradley_terry_by_mm(wins=wins, n_tasks=n_tasks)
-        dispatched = EloHelper._bradley_terry_from_win_totals(wins=wins, n_tasks=n_tasks)
-        assert np.array_equal(by_mm, dispatched, equal_nan=True)
-        assert np.isneginf(dispatched[wins == 0]).all()
-    assert checked > 0, "no winless field was generated, so nothing was tested"
+    assert np.isfinite(from_ranks.to_numpy()).all()
+    assert (from_ranks - from_battles.reindex(methods)).abs().max() < 1e-2
 
 
 def test_a_separable_field_lands_where_the_battle_path_does():


### PR DESCRIPTION
#500 kept the MM iteration for a field containing a **winless** method, on the grounds that the
unpenalised likelihood puts such a method at negative infinity and MM reaches that limit exactly.

But the ridge that PR introduced already answers that case. It is what stops the separable direction
running away — and it makes no difference whether that direction belongs to one winless method or to
a whole group that beats another group on every task. Both are the same degeneracy.

So the dispatch and the MM solver are both gone, and Bradley-Terry is solved exactly one way.

### Ratings are now finite everywhere

On a winless field where the battle path really does fit Bradley-Terry (C never wins, but the other
pairs are mixed, so two classes survive aggregation):

| method | battle path | this PR | delta |
|---|---|---|---|
| B | 1734.952695 | 1734.952713 | 1.7e-05 |
| A | 1675.366397 | 1675.366414 | 1.7e-05 |
| D | 1615.780103 | 1615.780121 | 1.7e-05 |
| **C** (winless) | **-1026.099195** | **-1026.099247** | **-5.2e-05** |

The battle path's `LogisticRegression` penalty has always made these finite; the fast path now
agrees rather than reporting `-inf`.

### Two special cases disappear with it

Both existed only to contain the infinity:

- the centring no longer has to exclude non-finite ratings before taking the mean;
- the error bars no longer have to special-case `inf - inf`, which produced `NaN` rather than a
  width.

### Unchanged

The 84-method leaderboard is byte-identical and the timing is the same (0.81s for a default
plot-free `compare()`). A fully separable field — where the battle path abandons Bradley-Terry for
an iterative Elo — still cannot be matched by any solver or penalty, and no real field hits it.

Tests updated: a winless field now asserts finite, ordered ratings and finite bars, and is checked
against the battle path directly.