### PR TITLE
Keep both labels in the Elo design so ratings do not depend on method names

### DIFF
--- a/packages/bencheval/src/bencheval/elo_utils.py
+++ b/packages/bencheval/src/bencheval/elo_utils.py
@@ -269,28 +269,24 @@ class EloHelper:
 
         if use_pair_aggregation and not force_iterative_elo:
             X, Y, sample_weight, model_to_idx = self._aggregate_battles_for_mle(battles, BASE=BASE)
-            if len(Y) == 0 or (np.unique(Y).size < 2):
-                # Degenerate draw (e.g., total dominance in a bootstrap): fall back.
-                logger.warning(
-                    "compute_mle_elo: only one class present after aggregation; falling back to iterative ELO."
+            if len(Y) == 0:
+                # Every pair is emitted with both labels, so an empty design means no pair of
+                # methods carries any weight -- there is nothing to rank, not a harder fit.
+                raise ValueError(
+                    f"Cannot compute Elo: none of the {len(battles)} battle(s) between "
+                    f"{len(models)} method(s) carry any weight, so no pair of methods has a "
+                    f"comparison to fit."
                 )
-                elo_scores = self.compute_iterative_elo_scores(
-                    df_original,
-                    INIT_RATING=INIT_RATING,
-                    SCALE=SCALE,
-                    models=models,
-                )
-                SeriesOut = pd.Series(elo_scores, index=models.index)
-            else:
-                lr = LogisticRegression(fit_intercept=False, max_iter=max_iter, C=1e6, tol=elo_solver_tol())
-                lr.fit(X, Y, sample_weight=sample_weight)
-                coef = lr.coef_[0]
-                # map coef -> ELO
-                elo_vec = SCALE * coef + INIT_RATING
-                # place into full model order
-                out = np.ones(len(models)) * INIT_RATING
-                out[model_to_idx.values] = elo_vec[model_to_idx.values]
-                SeriesOut = pd.Series(out, index=models.index)
+
+            lr = LogisticRegression(fit_intercept=False, max_iter=max_iter, C=1e6, tol=elo_solver_tol())
+            lr.fit(X, Y, sample_weight=sample_weight)
+            coef = lr.coef_[0]
+            # map coef -> ELO
+            elo_vec = SCALE * coef + INIT_RATING
+            # place into full model order
+            out = np.ones(len(models)) * INIT_RATING
+            out[model_to_idx.values] = elo_vec[model_to_idx.values]
+            SeriesOut = pd.Series(out, index=models.index)
         else:
             # duplicate battles
             battles = pd.concat([battles, battles], ignore_index=True)
@@ -858,6 +854,9 @@ class EloHelper:
           - Create two rows with the *same X*:
               y=1, weight = w_Awins + 0.5 * w_ties
               y=0, weight = w_Bwins + 0.5 * w_ties
+
+        Both rows are kept even at zero weight, so which labels appear does not depend on how the
+        pair was canonicalised. Only a pair neither method ever contested is dropped.
         """
         # model index mapping
         all_models = pd.concat([battles[self.method_1], battles[self.method_2]]).unique()
@@ -912,15 +911,17 @@ class EloHelper:
             x[model_to_idx[vi]] = -logB
 
             # y=1 row with A-side effective wins
-            if su > 0.0:
-                X_rows.append(x)
-                y_rows.append(1.0)
-                sw_rows.append(su)
+            # Both rows are emitted even when one side never won. A zero weight contributes nothing
+            # to the fit, but dropping the row would leave the design with a single label whenever
+            # every decisive pair happens to be won by the alphabetically earlier method -- which
+            # `compute_mle_elo` reads as unfittable and answers with a different estimator entirely.
+            X_rows.append(x)
+            y_rows.append(1.0)
+            sw_rows.append(su)
             # y=0 row with B-side effective wins
-            if sv > 0.0:
-                X_rows.append(x)
-                y_rows.append(0.0)
-                sw_rows.append(sv)
+            X_rows.append(x)
+            y_rows.append(0.0)
+            sw_rows.append(sv)
 
         X = np.vstack(X_rows) if X_rows else np.zeros((0, p))
         y = np.asarray(y_rows, dtype=float)
@@ -1131,53 +1132,35 @@ class EloHelper:
         SU_tot = counts @ SU  # (n_pairs,)
         SV_tot = counts @ SV  # (n_pairs,)
 
-        # If one class is missing, fall back to iterative path for this draw
-        has_pos = np.any(SU_tot > 0.0)
-        has_neg = np.any(SV_tot > 0.0)
-        if not (has_pos and has_neg):
-            # Build multiplicity map for tasks in this draw
-            mult_map = dict(zip(task_ids, counts, strict=False))
-            battles_boot = battles.copy()
-            if "weight" not in battles_boot.columns:
-                battles_boot["weight"] = 1.0
-            battles_boot["weight"] = battles_boot["weight"].to_numpy(dtype=float) * battles_boot[self.task_col].map(
-                mult_map
-            ).fillna(0.0).to_numpy(dtype=float)
-            elo_scores = self.compute_iterative_elo_scores(
-                battles_boot,
-                INIT_RATING=INIT_RATING,
-                SCALE=SCALE,
-                models=pd.Series(np.arange(len(model_to_idx)), index=model_to_idx.index),
-            )
-            ser = pd.Series(elo_scores, index=model_to_idx.index)
+        # Every pair contributes both labels, so the design is fittable even when a draw leaves one
+        # side of a pair with no wins at all -- that side simply carries zero weight.
+        # Interleaved sample weights: [SU_tot[0], SV_tot[0], SU_tot[1], SV_tot[1], ...]
+        n_pairs = SU_tot.size
+        sw = np.empty(2 * n_pairs, dtype=float)
+        sw[0::2] = SU_tot
+        sw[1::2] = SV_tot
+
+        # Optionally drop zero-weight pairs to shrink the fit
+        active_pairs = (SU_tot + SV_tot) > 0.0
+        if not np.all(active_pairs):
+            idx_pairs = np.flatnonzero(active_pairs)
+            row_idx = np.empty(2 * idx_pairs.size, dtype=int)
+            row_idx[0::2] = 2 * idx_pairs
+            row_idx[1::2] = 2 * idx_pairs + 1
+            X_fit, Y_fit, sw_fit = X2[row_idx], Y2[row_idx], sw[row_idx]
         else:
-            # Interleaved sample weights: [SU_tot[0], SV_tot[0], SU_tot[1], SV_tot[1], ...]
-            n_pairs = SU_tot.size
-            sw = np.empty(2 * n_pairs, dtype=float)
-            sw[0::2] = SU_tot
-            sw[1::2] = SV_tot
+            X_fit, Y_fit, sw_fit = X2, Y2, sw
 
-            # Optionally drop zero-weight pairs to shrink the fit
-            active_pairs = (SU_tot + SV_tot) > 0.0
-            if not np.all(active_pairs):
-                idx_pairs = np.flatnonzero(active_pairs)
-                row_idx = np.empty(2 * idx_pairs.size, dtype=int)
-                row_idx[0::2] = 2 * idx_pairs
-                row_idx[1::2] = 2 * idx_pairs + 1
-                X_fit, Y_fit, sw_fit = X2[row_idx], Y2[row_idx], sw[row_idx]
-            else:
-                X_fit, Y_fit, sw_fit = X2, Y2, sw
+        # Fit LR on the fixed design with per-draw weights
+        lr = LogisticRegression(fit_intercept=False, C=1e6, solver=solver, max_iter=max_iter, tol=elo_solver_tol())
+        lr.fit(X_fit, Y_fit, sample_weight=sw_fit)
 
-            # Fit LR on the fixed design with per-draw weights
-            lr = LogisticRegression(fit_intercept=False, C=1e6, solver=solver, max_iter=max_iter, tol=elo_solver_tol())
-            lr.fit(X_fit, Y_fit, sample_weight=sw_fit)
-
-            # Map coefficients -> ELO
-            coef = lr.coef_[0]  # aligned with model_to_idx order
-            elo_vec = SCALE * coef + INIT_RATING
-            out = np.ones(len(model_to_idx), dtype=float) * INIT_RATING
-            out[:] = elo_vec
-            ser = pd.Series(out, index=model_to_idx.index)
+        # Map coefficients -> ELO
+        coef = lr.coef_[0]  # aligned with model_to_idx order
+        elo_vec = SCALE * coef + INIT_RATING
+        out = np.ones(len(model_to_idx), dtype=float) * INIT_RATING
+        out[:] = elo_vec
+        ser = pd.Series(out, index=model_to_idx.index)
 
         # ---- Per-draw calibration (apply to the Series) ----
         if calibration_framework is not None:

--- a/tests/bencheval/test_elo_utils.py
+++ b/tests/bencheval/test_elo_utils.py
@@ -439,3 +439,88 @@ def test_a_separable_field_lands_where_the_battle_path_does():
     from_battles = helper.compute_mle_elo(battles=helper.convert_results_to_battles(results_df=results))
 
     assert (from_ranks - from_battles.reindex(methods)).abs().max() < 1.0
+
+
+def _strict_total_order(names: list[str], n_tasks: int = 10) -> pd.DataFrame:
+    """Every task ranks the methods in the same strict order, so every pair is decisive."""
+    return pd.DataFrame(
+        [(name, f"t{task}", float(i)) for task in range(n_tasks) for i, name in enumerate(names)],
+        columns=["method", "task", "metric_error"],
+    )
+
+
+def test_battle_path_elo_does_not_depend_on_method_names():
+    """Renaming a method must not change its rating, and once did on a decisive field.
+
+    Pairs are canonicalised by name, and a decisive pair contributed only its winning side. When
+    every winner sorted first, the design was left with a single label, which `compute_mle_elo` read
+    as unfittable and answered with an iterative Elo instead -- a different estimator, reached or not
+    according to spelling.
+    """
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+
+    ratings = []
+    for names in (["m0", "m1", "m2"], ["c", "b", "a"], ["b", "a", "c"]):
+        results = _strict_total_order(names)
+        elo = helper.compute_mle_elo(battles=helper.convert_results_to_battles(results_df=results))
+        ratings.append(elo.reindex(names).to_numpy())
+
+    for other in ratings[1:]:
+        assert np.abs(other - ratings[0]).max() < 1e-6, ratings
+
+
+def test_a_decisive_field_keeps_both_labels_in_the_design():
+    """The zero-weight row is what stops the fit from seeing a single class."""
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+    battles = helper.convert_results_to_battles(results_df=_strict_total_order(["m0", "m1", "m2"]))
+
+    _, labels, weights, _ = helper._aggregate_battles_for_mle(battles, BASE=10)
+
+    assert set(np.unique(labels)) == {0.0, 1.0}
+    assert (weights == 0).any(), "a strictly ordered field should produce zero-weight rows"
+
+
+def test_the_two_paths_agree_on_a_decisive_field():
+    """With both labels present the battle path fits Bradley-Terry, and the rank path matches it."""
+    results = _strict_total_order(["m0", "m1", "m2"])
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+
+    from_battles = helper.compute_mle_elo(battles=helper.convert_results_to_battles(results_df=results))
+    methods, win_matrix = helper._rank_win_matrix(results_per_task=results)
+    from_ranks = pd.Series(
+        EloHelper._bradley_terry_from_win_totals(wins=win_matrix.sum(axis=1), n_tasks=win_matrix.shape[1]),
+        index=methods,
+    )
+
+    assert (from_ranks - from_battles.reindex(methods)).abs().max() < 1.0
+
+
+def test_a_decisive_bootstrap_draw_still_fits_bradley_terry():
+    """Every draw must use the same estimator; one silently swapping is worse than a wide interval."""
+    results = _strict_total_order(["m0", "m1", "m2"], n_tasks=6)
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+
+    bootstrap = helper.compute_elo_ratings(
+        battles=helper.convert_results_to_battles(results_df=results),
+        BOOTSTRAP_ROUNDS=25,
+        show_process=False,
+    )
+    methods, win_matrix = helper._rank_win_matrix(results_per_task=results)
+    from_ranks = pd.Series(
+        EloHelper._bradley_terry_from_win_totals(wins=win_matrix.sum(axis=1), n_tasks=win_matrix.shape[1]),
+        index=methods,
+    )
+
+    # An iterative-Elo draw would land near INIT_RATING, hundreds of Elo from the Bradley-Terry fit.
+    assert (bootstrap.median() - from_ranks.reindex(bootstrap.columns)).abs().max() < 50
+
+
+def test_battles_with_no_weight_raise_rather_than_returning_a_rating():
+    """Nothing to rank is a broken input, not a harder fit to fall back on."""
+    results = _strict_total_order(["m0", "m1", "m2"], n_tasks=2)
+    helper = EloHelper(method_col="method", task_col="task", error_col="metric_error")
+    battles = helper.convert_results_to_battles(results_df=results)
+    battles["weight"] = 0.0
+
+    with pytest.raises(ValueError, match="carry any weight"):
+        helper.compute_mle_elo(battles=battles)


### PR DESCRIPTION
`_aggregate_battles_for_mle` canonicalises each unordered pair by **name** (`u = min(a, b)`) and
emitted a row only for a side that actually won something. On a field where every pair is decisive
that leaves one row per pair — and if every winner happens to sort first, every row carries the same
label. `compute_mle_elo` treats a single class as unfittable and falls back to an iterative Elo.

So which estimator ran depended on how the methods were spelled:

```
3 methods,  m0 < m1 < m2   -> iterative Elo
15 methods, m0..m14        -> LogisticRegression   (lexical order breaks at m10)
15 methods, m00..m14       -> iterative Elo        (same data, zero-padded names)
```

Identical data, identical strengths, different ratings — and not slightly different: the iterative
Elo clusters everything within ~30 Elo of 1000 where the Bradley-Terry fit spreads it over
thousands.

## The fix

Emit both rows whatever their weight. A zero-weight row contributes nothing to the weighted loss, so
it is free where it does not matter and decisive where it does; only a pair neither method contested
is still dropped.

## The bootstrap had the same guard

`_bootstrap_draw_compressed` bailed to an iterative Elo whenever a draw left one side globally
empty. That fires on **every draw** of a decisive field (100/100 measured), and its design already
carries both labels — so the guard only ever swapped estimators for a draw the fit would have
handled perfectly well. Bypassing it gives `[3535.35, 1000.00, -1535.35]` against the rank path's
`[3535.36, 1000.00, -1535.36]`, a **0.01 Elo** difference.

A bootstrap whose draws are not all fit the same way produces an interval that does not mean
anything, so that guard is removed too. It never fires on the real field (0/200 draws).

## An empty design now raises

The original condition was `len(Y) == 0 or np.unique(Y).size < 2`. With both labels always present
the second half can no longer fire, and the first means *no pair of methods carries any weight* —
there is nothing to rank. Passing that into an estimator to get ratings back is worse than failing,
so it raises with the battle and method counts instead.

## Impact

**The real field is untouched.** Every pair there already has both sides winning something, so the
design is the same 6972 rows, there are no zero-weight rows at all, `compute_mle_elo` takes the same
0.98s, and the 84-method leaderboard through the slow path is byte-identical. The fast path is
unaffected.

On a decisive field, all three spellings above now agree, and the battle path matches the rank path
where the two previously differed by thousands of Elo.

## What is left of the iterative Elo

`compute_iterative_elo_scores` stays: it is still reachable through the explicit
`force_iterative_elo` / `use_pair_aggregation=False` arguments, and is covered by its own test. What
is gone is reaching it *by accident* — from a condition that tracked method naming, or from an input
that was simply invalid.

Found while checking what the rank path does on separable fields: the disagreement there turned out
to be the battle path's, not the rank path's.