### PR TITLE
Make the time figure an option on compare instead of always drawing it

### DIFF
--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -35,6 +35,7 @@ def compare(
     elo_ymin: float | None = None,
     benchmark_name: str = "Arena",
     plot: bool = True,
+    plot_times: bool = False,
     **kwargs,
 ):
     """Evaluate ``df_results`` (already subset to the tasks of interest) into a leaderboard.
@@ -45,6 +46,9 @@ def compare(
     ``output_dir=None`` makes this compute-only: the leaderboard is returned without writing a
     file or rendering a figure. ``plot=False`` keeps the CSVs but skips every figure. Both are
     described in :meth:`LeaderboardReporter.eval`.
+
+    ``plot_times`` opts into the train/infer time figure (``time_plot``), off by default: it is a
+    deep dive rather than part of the leaderboard, and the callers that want it are few.
     """
     df_results = prepare_data(
         df_results=df_results,
@@ -80,7 +84,7 @@ def compare(
         df_results=df_results,
         plot=plot,
         plot_extra_barplots=False,
-        plot_times=True,
+        plot_times=plot_times,
         calibration_framework=calibration_framework,
         average_seeds=average_seeds,
         leaderboard_kwargs=leaderboard_kwargs,

--- a/tests/tabarena/nips2025_utils/test_compare_plot_options.py
+++ b/tests/tabarena/nips2025_utils/test_compare_plot_options.py
@@ -1,0 +1,73 @@
+"""`compare` forwards its figure options rather than fixing them."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tabarena.benchmark.task.metadata import TaskMetadataCollection
+from tabarena.evaluation.leaderboard_reporter import LeaderboardReporter
+from tabarena.nips2025_utils import compare as compare_module
+
+
+@pytest.fixture
+def task_metadata() -> TaskMetadataCollection:
+    return TaskMetadataCollection.from_legacy_df(
+        pd.DataFrame(
+            {
+                "dataset": ["ds"],
+                "name": ["ds"],
+                "tid": [0],
+                "problem_type": ["binary"],
+                "n_folds": [2],
+                "n_repeats": [1],
+                "n_features": [3],
+                "n_classes": [2],
+                "NumberOfInstances": [150],
+                "n_samples_train_per_fold": [100],
+                "n_samples_test_per_fold": [50],
+                "target_feature": ["t"],
+            }
+        )
+    )
+
+
+@pytest.fixture
+def df_results() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "method": ["a", "b", "a", "b"],
+            "dataset": ["ds"] * 4,
+            "fold": [0, 0, 1, 1],
+            "metric_error": [0.1, 0.2, 0.15, 0.25],
+            "metric": ["roc_auc"] * 4,
+            "problem_type": ["binary"] * 4,
+            "time_train_s": [1.0] * 4,
+            "time_infer_s": [0.1] * 4,
+        }
+    )
+
+
+@pytest.fixture
+def captured_eval_kwargs(monkeypatch) -> dict:
+    """Stop at the `eval` call: what matters here is which options reach it."""
+    captured: dict = {}
+
+    def fake_eval(self, **kwargs):
+        captured.update(kwargs)
+        return pd.DataFrame()
+
+    monkeypatch.setattr(LeaderboardReporter, "eval", fake_eval)
+    return captured
+
+
+def test_the_time_figure_is_off_unless_asked_for(df_results, task_metadata, captured_eval_kwargs):
+    compare_module.compare(df_results=df_results, output_dir=None, task_metadata=task_metadata)
+
+    assert captured_eval_kwargs["plot_times"] is False
+
+
+def test_the_time_figure_can_be_asked_for(df_results, task_metadata, captured_eval_kwargs):
+    compare_module.compare(df_results=df_results, output_dir=None, task_metadata=task_metadata, plot_times=True)
+
+    assert captured_eval_kwargs["plot_times"] is True


### PR DESCRIPTION
`compare` passed `plot_times=True` to `eval` literally, so `time_plot` was drawn on every call — and
there was no way to turn it off, because the argument was already taken:

```
TypeError: LeaderboardReporter.eval() got multiple values for keyword argument 'plot_times'
```

The only way to skip the figure was editing `nips2025_utils/compare.py`.

It is now a `compare` parameter defaulting to `False`. The figure is a train/infer time deep dive
rather than part of the leaderboard, and nothing in the repo reads the file.

| | |
|---|---|
| `compare(...)` | no `time_plot`, **5.63s** |
| `compare(..., plot_times=True)` | `time_plot.pdf` written, 5.82s |

So this is about control, not speed — it is worth ~0.13s of a 5.8s plotted call. The figures that
cost real time are the pareto fronts (4.3s) and the win-rate matrix (2.8s), both of which already
have toggles.

One thing worth not confusing: this is unrelated to `plot_runtimes` / `generate_runtime_plot`, which
is a *different* figure and already defaults off. `time_plot` comes from `plot_tabarena_times`.

Tests assert the option is off by default and forwarded when set.