### PR TITLE
Let the win-rate matrix figure be switched off

### DIFF
--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -800,6 +800,7 @@ class LeaderboardReporter:
         plot_critical_diagrams: bool = False,
         plot_runtimes: bool = False,
         plot_pareto: bool = True,
+        plot_winrate_matrix: bool = True,
         plot_metric_boxplots: str | list[str] | bool = False,
         metric_boxplot_kwargs: dict | None = None,
         plot_date_introduced: bool = False,
@@ -838,6 +839,11 @@ class LeaderboardReporter:
         ``tuning-impact-elo`` bar plot, the win-rate matrix, and the Pareto
         figures + interactive explorer), skipping the rest of the paper
         figure suite (LaTeX tables, the horizontal Elo bar plot).
+
+        ``plot_winrate_matrix`` (default ``True``) draws the win-rate matrix figure and its
+        interactive page. The matrix itself is still computed and written to ``winrate_matrix.csv``
+        either way, since the website reads it -- this only skips rendering, which is the expensive
+        part on a large field.
 
         ``plot_date_introduced`` (default ``False``) opts into the
         ``{elo,improvability}_vs_date_introduced`` scatters and their GIF
@@ -1352,7 +1358,7 @@ class LeaderboardReporter:
                         winrate_title = f"{self.benchmark_name}-{subset_label} Win-rate Matrix"
                     else:
                         winrate_title = f"{self.benchmark_name} Win-rate Matrix"
-                if plot:
+                if plot and plot_winrate_matrix:
                     try:
                         tabarena.plot_winrate_matrix(
                             winrate_matrix=winrate_matrix_best,
@@ -1377,7 +1383,7 @@ class LeaderboardReporter:
                         df=winrate_matrix_best,
                         index=True,
                     )
-                if plot:
+                if plot and plot_winrate_matrix:
                     build_winrate_explorer_html(
                         winrate_matrix=winrate_matrix,
                         save_path=Path(self.output_dir) / "winrate_explorer.html",

--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -36,6 +36,7 @@ def compare(
     benchmark_name: str = "Arena",
     plot: bool = True,
     plot_times: bool = False,
+    plot_winrate_matrix: bool = True,
     **kwargs,
 ):
     """Evaluate ``df_results`` (already subset to the tasks of interest) into a leaderboard.
@@ -49,6 +50,10 @@ def compare(
 
     ``plot_times`` opts into the train/infer time figure (``time_plot``), off by default: it is a
     deep dive rather than part of the leaderboard, and the callers that want it are few.
+
+    ``plot_winrate_matrix`` skips the win-rate figure and its interactive page when ``False``. The
+    matrix is still computed and written as CSV; on a large field the rendering is what costs, since
+    every cell carries a label.
     """
     df_results = prepare_data(
         df_results=df_results,
@@ -85,6 +90,7 @@ def compare(
         plot=plot,
         plot_extra_barplots=False,
         plot_times=plot_times,
+        plot_winrate_matrix=plot_winrate_matrix,
         calibration_framework=calibration_framework,
         average_seeds=average_seeds,
         leaderboard_kwargs=leaderboard_kwargs,

--- a/tests/tabarena/nips2025_utils/test_compare_plot_options.py
+++ b/tests/tabarena/nips2025_utils/test_compare_plot_options.py
@@ -71,3 +71,17 @@ def test_the_time_figure_can_be_asked_for(df_results, task_metadata, captured_ev
     compare_module.compare(df_results=df_results, output_dir=None, task_metadata=task_metadata, plot_times=True)
 
     assert captured_eval_kwargs["plot_times"] is True
+
+
+def test_the_winrate_matrix_figure_is_drawn_by_default(df_results, task_metadata, captured_eval_kwargs):
+    compare_module.compare(df_results=df_results, output_dir=None, task_metadata=task_metadata)
+
+    assert captured_eval_kwargs["plot_winrate_matrix"] is True
+
+
+def test_the_winrate_matrix_figure_can_be_skipped(df_results, task_metadata, captured_eval_kwargs):
+    compare_module.compare(
+        df_results=df_results, output_dir=None, task_metadata=task_metadata, plot_winrate_matrix=False
+    )
+
+    assert captured_eval_kwargs["plot_winrate_matrix"] is False


### PR DESCRIPTION
Rendering the win-rate matrix is the single most expensive figure in a plotted `compare()` — an
84x84 grid where every cell carries a label, so it is thousands of text layout computations. Unlike
the pareto fronts (`plot_pareto`) and the critical diagrams (`plot_cdd`), there was no way to skip
it.

`plot_winrate_matrix` defaults to `True`, so nothing changes unless asked for.

| | |
|---|---|
| `compare(...)` | figure + explorer written, **5.64s** |
| `compare(..., plot_winrate_matrix=False)` | **4.30s** (-1.34s, 24%) |

## What the toggle covers

The figure **and** its interactive page, matching how `plot_pareto` already covers its four figures
and `build_pareto_explorer`.

It deliberately does **not** cover `winrate_matrix.csv`: the matrix is still computed and written
either way, because `process_artifacts_to_website.py` reads that file. It is the rendering, not the
computation, that costs — the underlying `compute_winrate` is now ~15ms after #497.

Verified with the flag off: `winrate_matrix.csv` is byte-identical (42x42) and so is the leaderboard.

Tests assert the option is on by default and forwarded when set.