### PR TITLE
Run the subset passes in parallel and write the composite leaderboard by default

### DIFF
--- a/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import contextlib
 import copy
 import functools
+import os
 import tempfile
 from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
@@ -58,6 +59,19 @@ if TYPE_CHECKING:
 # expname" (fall back to `cache_config.results`, else error) from an explicit `expname=None`
 # (always a throwaway temp dir). Keeps the original "expname is required; None means throwaway" API.
 _EXPNAME_UNSET: Any = object()
+
+
+def _default_max_workers() -> int:
+    """One process per available CPU less one, so the machine keeps a core for everything else.
+
+    Counts the CPUs this process may actually run on rather than the ones the machine has, which
+    differ under an affinity mask or a container quota.
+    """
+    if hasattr(os, "sched_getaffinity"):
+        available = len(os.sched_getaffinity(0))
+    else:
+        available = os.cpu_count() or 1
+    return max(1, available - 1)
 
 
 class AbstractArenaContext:
@@ -1182,10 +1196,10 @@ class AbstractArenaContext:
         save_website_leaderboard: bool = False,
         website_leaderboard_kwargs: dict | None = None,
         website_leaderboard_filename: str = "leaderboard_website.csv",
-        save_composite_leaderboard: bool = False,
+        save_composite_leaderboard: bool | None = None,
         composite_leaderboard_kwargs: dict | None = None,
         trajectory_extra_results: pd.DataFrame | None = None,
-        max_workers: int = 1,
+        max_workers: int | None = None,
     ) -> None:
         """Generate the compare / tuning-trajectory / runtime figures for each subset.
 
@@ -1206,7 +1220,8 @@ class AbstractArenaContext:
         while the leaderboard still reports them. ``compare``-only task scoping (``tasks``) has no
         trajectory counterpart and stays in ``compare_kwargs``.
 
-        ``save_composite_leaderboard=True`` additionally aggregates the per-subset leaderboards
+        ``save_composite_leaderboard`` (``None`` by default: on whenever ``plot_compare`` is)
+        additionally aggregates the per-subset leaderboards
         into a single composite table (rows = (method, metric), one column per subset) written to
         ``<output_dir>/composite_leaderboard.csv`` plus color-graded PNG renderings — see
         :func:`tabarena.plot.composite_leaderboard.generate_composite_leaderboard`, which
@@ -1215,10 +1230,12 @@ class AbstractArenaContext:
         built from the compact website format independently of ``save_website_leaderboard``.
 
         ``max_workers`` parallelizes the per-subset passes across processes (capped at the subset
-        count; 1 = sequential). Each subset's compare/plots are independent and write to their own
-        directory, so they compose freely; processes (not threads) because the passes are CPU-bound
-        (Elo bootstrap, plotting) and matplotlib is not thread-safe. Requires the context (and any
-        results frames passed in) to be picklable.
+        count; 1 = sequential). ``None`` (the default) uses one process per available CPU less one,
+        leaving a core for everything else. Each subset's compare/plots are independent and write to
+        their own directory, so they compose freely; processes (not threads) because the passes are
+        CPU-bound (Elo bootstrap, plotting) and matplotlib is not thread-safe. Requires the context
+        (and any results frames passed in) to be picklable -- pass ``max_workers=1`` for a context
+        that is not.
         """
         if compare_kwargs is None:
             compare_kwargs = {}
@@ -1244,6 +1261,10 @@ class AbstractArenaContext:
                 "save_composite_leaderboard=True requires plot_compare=True: the composite is "
                 "aggregated from the per-subset leaderboards computed by the compare pass.",
             )
+        # Default to writing it whenever the leaderboards it aggregates are being produced, rather
+        # than making a trajectories-only run (`plot_compare=False`) fail on a default it never set.
+        if save_composite_leaderboard is None:
+            save_composite_leaderboard = plot_compare
         if subsets == "auto":
             subsets = self._default_subsets
         output_dir = Path(output_dir)
@@ -1264,6 +1285,8 @@ class AbstractArenaContext:
             collect_composite=save_composite_leaderboard,
             trajectory_extra_results=trajectory_extra_results,
         )
+        if max_workers is None:
+            max_workers = _default_max_workers()
         max_workers = max(1, min(max_workers, len(subsets)))
         if max_workers == 1:
             subset_results = [self._generate_subset_figs(subset, **subset_fig_kwargs) for subset in subsets]

--- a/tests/tabarena/contexts/test_generate_all_figs_task_scope.py
+++ b/tests/tabarena/contexts/test_generate_all_figs_task_scope.py
@@ -80,6 +80,9 @@ def test_generate_all_figs_forwards_the_same_scope_to_both_passes(monkeypatch, t
         compare_kwargs={"folds": [0, 1, 2], "datasets": ["d1"]},
         plot_compare=True,
         plot_tuning_trajectories=True,
+        # This context is a hollow object, and the composite needs a real method metadata
+        # collection to build. Scope forwarding is what is under test here.
+        save_composite_leaderboard=False,
     )
 
     for pass_name in ("compare", "trajectory"):

--- a/tests/tabarena/contexts/test_generate_all_figs_workers.py
+++ b/tests/tabarena/contexts/test_generate_all_figs_workers.py
@@ -1,0 +1,81 @@
+"""How ``generate_all_figs`` decides how many processes to run the subset passes in."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from tabarena.contexts import abstract_arena_context
+from tabarena.contexts.abstract_arena_context import AbstractArenaContext, _default_max_workers
+
+
+@pytest.mark.parametrize(("available", "expected"), [(1, 1), (2, 1), (8, 7), (48, 47)])
+def test_one_process_per_cpu_less_one(monkeypatch, available: int, expected: int):
+    """A core is left for everything else, and a single-CPU machine still gets one worker."""
+    monkeypatch.setattr(abstract_arena_context.os, "sched_getaffinity", lambda _pid: set(range(available)))
+
+    assert _default_max_workers() == expected
+
+
+def test_cpus_are_counted_as_the_ones_this_process_may_use(monkeypatch):
+    """An affinity mask or container quota makes that smaller than the machine's CPU count."""
+    monkeypatch.setattr(abstract_arena_context.os, "sched_getaffinity", lambda _pid: {0, 1, 2, 3})
+    monkeypatch.setattr(abstract_arena_context.os, "cpu_count", lambda: 256)
+
+    assert _default_max_workers() == 3
+
+
+def test_falls_back_to_cpu_count_without_affinity_support(monkeypatch):
+    """`sched_getaffinity` is Linux-only."""
+    monkeypatch.delattr(abstract_arena_context.os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(abstract_arena_context.os, "cpu_count", lambda: 4)
+
+    assert _default_max_workers() == 3
+
+
+def test_an_unknown_cpu_count_still_yields_a_worker(monkeypatch):
+    monkeypatch.delattr(abstract_arena_context.os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(abstract_arena_context.os, "cpu_count", lambda: None)
+
+    assert _default_max_workers() == 1
+
+
+def test_max_workers_defaults_to_auto():
+    """`None` is the sentinel the auto path keys off; an explicit count must still be honoured."""
+    assert inspect.signature(AbstractArenaContext.generate_all_figs).parameters["max_workers"].default is None
+
+
+def test_the_composite_leaderboard_is_written_by_default():
+    """`None` means "whenever the leaderboards it aggregates are produced"."""
+    default = inspect.signature(AbstractArenaContext.generate_all_figs).parameters["save_composite_leaderboard"].default
+    assert default is None
+
+
+def test_asking_for_the_composite_without_the_compare_pass_is_an_error():
+    """Explicitly requesting it with nothing to aggregate is a mistake worth naming."""
+    with pytest.raises(ValueError, match="requires plot_compare=True"):
+        AbstractArenaContext.generate_all_figs(
+            AbstractArenaContext.__new__(AbstractArenaContext),
+            output_dir="unused",
+            plot_compare=False,
+            save_composite_leaderboard=True,
+        )
+
+
+def test_a_trajectories_only_run_does_not_trip_over_the_default(monkeypatch):
+    """The default must not turn `plot_compare=False` into a failure it never asked for."""
+    captured = {}
+
+    def fake_subset_figs(self, subset, **kwargs):
+        captured["collect_composite"] = kwargs["collect_composite"]
+        return ("", None)
+
+    monkeypatch.setattr(AbstractArenaContext, "_generate_subset_figs", fake_subset_figs)
+    monkeypatch.setattr(AbstractArenaContext, "_default_subsets", property(lambda self: [[]]))
+
+    AbstractArenaContext.generate_all_figs(
+        AbstractArenaContext.__new__(AbstractArenaContext), output_dir="unused", plot_compare=False
+    )
+
+    assert captured["collect_composite"] is False


### PR DESCRIPTION
Two defaults on `generate_all_figs`.

## `max_workers` defaults to one process per CPU less one

The subset passes are independent and write to their own directories, but ran one at a time unless
the caller opted in. `None` now means `available CPUs - 1`, leaving a core for everything else, and
is still capped at the subset count.

| | |
|---|---|
| `max_workers=1` (previous default) | 42.5s, peak RSS 629 MB |
| `max_workers=None` (new default) | **12.8s**, 350 MB parent + ~516 MB per child |

CPUs are counted with `sched_getaffinity` rather than `cpu_count`, so an affinity mask or container
quota is respected instead of over-committing to the machine's nominal core count.

Worth noting this is only practical since the Elo work earlier this session: each worker used to
hold a multi-GB battle table, so eight of them wanted ~24 GB. They now peak around 516 MB.

`max_workers=1` remains the escape hatch for a context that cannot be pickled — the docstring says
so.

## `save_composite_leaderboard` defaults to on

It now defaults to `None`, meaning *whenever the leaderboards it aggregates are being produced*.

A plain `True` would have been a trap: `generate_all_figs` raises when the composite is requested
without `plot_compare`, so a trajectories-only run would have started failing over a default it
never set. Asking for it explicitly without the compare pass still raises, because that is a genuine
mistake.

One existing test needed `save_composite_leaderboard=False` added: it drives `generate_all_figs`
with a deliberately hollow context object to check task-scope forwarding, and the composite step
needs a real method metadata collection.

Tests cover the CPU count (including the single-CPU floor, an affinity mask, and no affinity
support), both defaults, and that a trajectories-only run no longer trips over the composite.