### PR TITLE
PyPI releases for bencheval and tabarena: workflows, staged build script, metadata fixes

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,46 @@
+# Publish a `.dev` build of bencheval + tabarena to PyPI for every push to
+# `main` whose tests passed. The version is `<next patch>.dev<UTC timestamp>`,
+# derived on the runner from the pyproject version; no tag, no commit, no
+# GitHub Release. Users opt in with `pip install --pre tabarena`.
+#
+# Gated on the "Python application" workflow (pytest + ruff) succeeding for
+# that commit, so a broken main is never published. Runs are serialized so
+# the timestamps stay in commit order.
+
+name: Dev release (PyPI)
+
+on:
+  workflow_run:
+    workflows: ["Python application"]
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: pypi-dev-release
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # PyPI trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build + verify distributions
+        run: python scripts/release/build_pypi_dists.py --dev
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always dist/*

--- a/.github/workflows/install-benchmark.yml
+++ b/.github/workflows/install-benchmark.yml
@@ -1,6 +1,9 @@
-# Verify both ends of the install spectrum (issue #323):
-#  - install-minimal:   bare `tabarena` core imports without pulling heavy optional deps.
-#  - install-benchmark: `tabarena[benchmark]` resolves and installs end-to-end.
+# Verify both ends of the install spectrum (issue #323), plus the PyPI build:
+#  - install-minimal:    bare `tabarena` core imports without pulling heavy optional deps.
+#  - install-benchmark:  `tabarena[benchmark]` resolves and installs end-to-end.
+#  - install-from-wheel: `scripts/release/build_pypi_dists.py` builds publishable bencheval +
+#                        tabarena wheels (no direct-URL deps, README/LICENSE, all data files) and a
+#                        non-editable install of them imports with its data files in place.
 
 name: install-benchmark
 
@@ -84,3 +87,50 @@ jobs:
       - name: Verify import
         run: |
           python -c "import tabarena; print('tabarena import OK')"
+
+  install-from-wheel:
+    name: Build PyPI dists + install from wheel
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build + verify bencheval and tabarena distributions
+        run: python scripts/release/build_pypi_dists.py --out-dir dist
+
+      - name: Install tabarena[plot] from the built wheels (non-editable)
+        run: |
+          uv pip install --system --prerelease=allow \
+            "tabarena[plot] @ $(realpath dist/tabarena-*.whl)" dist/bencheval-*.whl
+
+      - name: Verify import and shipped data files
+        run: |
+          # Run outside the checkout so `import tabarena` cannot pick up packages/tabarena/src.
+          cd "$RUNNER_TEMP"
+          python - <<'PY'
+          import importlib.metadata as md
+          from pathlib import Path
+
+          import bencheval  # noqa: F401
+          import tabarena
+          from tabarena.models import get_model_registry
+
+          get_model_registry()
+          pkg = Path(tabarena.__file__).parent
+          assert "site-packages" in str(pkg), pkg
+          for rel in (
+              "models/limix/_vendor/config/cls_default_16M_retrieval.json",
+              "benchmark/task/metadata/data/curated_tabarena_dataset_metadata.csv",
+              "metrics/_cpp_metrics/cpp_metrics.cpp",
+          ):
+              assert (pkg / rel).is_file(), f"missing from the wheel install: {rel}"
+          print(f"tabarena {md.version('tabarena')} + bencheval {md.version('bencheval')} import OK; data files present")
+          PY

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,44 @@
+# Publish a PEP 440 pre-release (alpha/beta/rc/dev) of bencheval + tabarena to
+# PyPI without a git tag, commit, or GitHub Release. The version is applied to
+# a staged copy on the runner only; nothing is pushed back to the repository.
+#
+# Trigger from the Actions UI: Actions -> "Prerelease (PyPI)" -> Run workflow ->
+# enter the version (e.g. 0.1.0a1, 0.1.0b2, 0.1.0rc1, 0.1.0.dev3), or:
+#   gh workflow run prerelease.yml -f version=0.1.0a1
+#
+# Stable versions are rejected; push a `v<version>` tag for those (release.yml).
+
+name: Prerelease (PyPI)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Pre-release version (e.g. 0.1.0a1, 0.1.0b2, 0.1.0rc1, 0.1.0.dev3)"
+        required: true
+        type: string
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # PyPI trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build + verify distributions (stable versions are rejected)
+        env:
+          VERSION: ${{ inputs.version }}
+        run: python scripts/release/build_pypi_dists.py --version "$VERSION" --require-prerelease
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# Stable PyPI release of bencheval + tabarena.
+#
+# Trigger: push a tag `v<version>` whose version equals the `version` in both
+# packages/bencheval/pyproject.toml and packages/tabarena/pyproject.toml. The
+# build script refuses to build otherwise. Publishes both distributions to PyPI
+# through trusted publishing (OIDC, no stored token) and creates a GitHub
+# Release with the files attached.
+#
+# One-time setup (PyPI trusted publishers, the `pypi` environment) and the
+# version scheme: AGENTS.md, "Releasing to PyPI (maintainers)".
+
+name: Release (PyPI)
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: write   # create the GitHub Release
+      id-token: write   # PyPI trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build + verify distributions (tag must match pyproject)
+        run: python scripts/release/build_pypi_dists.py --check-tag "$GITHUB_REF_NAME"
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always dist/*
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,27 @@ python scripts/run_upload_results.py --method-metadata tabarena.models.nori.info
 # Add model to the collection in `packages/tabarena/src/tabarena/contexts/tabarena/methods.py`
 ```
 
+### Releasing to PyPI (maintainers)
+
+The git checkout is the recommended install. PyPI carries an experimental copy of `bencheval` and `tabarena` so downstream packages can depend on them without git URLs (issue #495). The two packages share one version (`version` in both `packages/*/pyproject.toml` must be equal), and every `tabarena` release pins `bencheval==<version>`.
+
+`scripts/release/build_pypi_dists.py` builds both packages from a staged copy, so the checkout is never modified, and then verifies the wheels. Compared to the pyproject files in the repo, the PyPI build sets the version and the `bencheval` pin, strips requirements with a direct URL (`name @ git+...`, which PyPI rejects) so that `tabarena[tabfm]`, `[sap-rpt-oss]` and `[exaone_tabular]` are empty on PyPI while the model's `pip_extra` in its `info.py` keeps the git dependency for the install hint, and copies the root `README.md` (relative links made absolute) and `LICENSE` next to each pyproject. The verification fails on a leftover direct URL, an empty description, a missing license file, or a git-tracked non-`.py` file under `src/` that the package-data globs missed. The `install-from-wheel` job in `.github/workflows/install-benchmark.yml` runs the build on every PR and installs the wheels non-editable.
+
+All three publishing workflows run in the `pypi` GitHub environment and authenticate with PyPI trusted publishing (OIDC), so no token is stored anywhere:
+
+| Workflow | Trigger | Version | Purpose |
+|---|---|---|---|
+| `release.yml` | push a tag `v<version>` | must equal both pyproject versions | stable release plus a GitHub Release with the files attached |
+| `prerelease.yml` | Actions UI, or `gh workflow run prerelease.yml -f version=0.1.0a1` | the input; must carry an `a`/`b`/`rc`/`.dev` segment; repo untouched | alpha/beta/rc for testers |
+| `dev-release.yml` | every push to `main` once "Python application" passes | `<next patch>.dev<UTC timestamp>` | `pip install --pre tabarena` tracks `main` |
+
+To cut a stable release, bump `version` in both pyproject files in a PR, merge it, then `git tag v<version> && git push origin v<version>`. Pre-releases and dev builds never change the repository. Local dry run: `python scripts/release/build_pypi_dists.py --version 0.1.0a1` writes the checked distributions to `dist/` (needs `uv` on PATH).
+
+One-time setup, and who can do it:
+
+- PyPI trusted publishers need the PyPI project owner. For each of `tabarena` and `bencheval`, add one publisher per workflow file (`release.yml`, `prerelease.yml`, `dev-release.yml`) with owner `autogluon`, repository `tabarena`, environment `pypi`. `bencheval` does not exist on PyPI yet, so add it as a pending publisher, which reserves the name until the first upload. Until this is done, `uv publish --trusted-publishing always` fails with an OIDC error instead of publishing.
+- The `pypi` GitHub environment is created by GitHub on the first workflow run that references it. Protection rules on it (required reviewers, restricting deployments to tags) need repository admin rights, which maintainers with push access do not have; ask an `autogluon` org admin.
+
 ## Conventions
 
 - **Add a new model**: create one folder `packages/tabarena/src/tabarena/models/<model>/` (`model.py`, `hpo.py`, `info.py`, `__init__.py`), then edit `models/__init__.py` (lazy class entry), `models/utils.py` (name→generator map), and `packages/tabarena/pyproject.toml` (a per-model extra). The registry auto-discovers the model from its `info.py`, and `tests/tabarena/models/test_all_models.py` then fits it automatically — there is **no per-model test file**. Only add an entry to `tests/tabarena/models/smoke_configs.py` if the smoke fit needs faster toy hyperparameters or a restricted problem-type set (keyed by the model's `MethodMetadata.method`). **Use the `add-model` skill**, which encodes this and points to reference implementations (foundation / torch / sklearn).

--- a/README.md
+++ b/README.md
@@ -163,15 +163,30 @@ uv pip install --prerelease=allow -e "./tabarena/packages/tabarena[benchmark]"
 </details>
 
 <details>
+<summary><b>🧪 PyPI</b> — experimental pre-releases, no clone needed</summary>
+
+`tabarena` and `bencheval` are published to PyPI as pre-releases for projects that cannot depend on git URLs, so pass `--pre` (pip) or `--prerelease=allow` (uv). The core package and `[plot]` are complete. Model extras whose upstream package is only available from git (`tabfm`, `sap-rpt-oss`, `exaone_tabular`) are empty on PyPI; the model's install hint tells you what to install by hand. The git checkout above stays the recommended install.
+
+```bash
+uv pip install --prerelease=allow "tabarena[plot]"   # or: pip install --pre "tabarena[plot]"
+uv pip install --prerelease=allow bencheval          # leaderboard engine only
+```
+</details>
+
+<details>
 <summary><b>📦 Use TabArena as a dependency</b></summary>
 
-Add the following to your project's dependencies:
+Add one of the following to your project's dependencies:
 
 ```toml
 # TabArena depends on a pre-release of AutoGluon, so allow pre-releases when installing
 # (e.g. `uv pip install --prerelease=allow ...` or `pip install --pre ...`).
 # Alternatively, pin AutoGluon to a specific pre-release (an exact `==` pin resolves a
 # pre-release without the flag), e.g. add `"autogluon.tabular==1.5.1b20260626"`.
+
+# From PyPI (experimental pre-releases; each tabarena release pins its matching bencheval):
+"tabarena>=0.1.0a1"
+# From git (tip of main; publishable to PyPI only as a source-only extra, see issue #495):
 "tabarena @ git+https://github.com/autogluon/tabarena.git#subdirectory=packages/tabarena"
 ```
 

--- a/packages/bencheval/README.md
+++ b/packages/bencheval/README.md
@@ -1,0 +1,51 @@
+# bencheval
+
+Benchmark evaluation for tabular machine learning: turns a table of per-task results into a
+leaderboard with Elo, win-rates, average ranks, improvability, and bootstrap confidence intervals.
+It is the leaderboard engine behind [TabArena](https://tabarena.ai/) and is developed in the
+[TabArena repository](https://github.com/autogluon/tabarena), but it does not depend on the
+`tabarena` package, so any benchmark that produces `(method, task, metric_error)` rows can use it.
+
+> **Experimental.** The API is still moving. Pin the version you evaluate with; every `tabarena`
+> release pins the matching `bencheval` release.
+
+## Install
+
+```bash
+pip install --pre bencheval          # metrics + leaderboards
+pip install --pre "bencheval[plot]"  # + matplotlib / seaborn / plotly for the plotting mixin
+```
+
+Releases on PyPI are pre-releases for now, so `--pre` (or `uv pip install --prerelease=allow`) is
+needed. The git checkout is the recommended install for development; see the
+[TabArena README](https://github.com/autogluon/tabarena#readme).
+
+## Usage
+
+```python
+import pandas as pd
+from bencheval.evaluator import BenchmarkEvaluator
+
+# One row per (method, task[, seed]); lower `metric_error` is better.
+data = pd.DataFrame(
+    {
+        "method": ["A", "B", "A", "B"],
+        "task": ["t1", "t1", "t2", "t2"],
+        "seed": [0, 0, 0, 0],
+        "metric_error": [0.10, 0.12, 0.30, 0.25],
+        "time_train_s": [1.0, 2.0, 1.5, 2.5],
+        "time_infer_s": [0.1, 0.2, 0.1, 0.2],
+    }
+)
+
+evaluator = BenchmarkEvaluator(seed_column="seed")
+leaderboard = evaluator.leaderboard(data, include_error=True)
+print(leaderboard)
+```
+
+`examples/plots/run_generate_custom_leaderboard.py` in the TabArena repository shows custom
+leaderboard metrics, Elo calibration against a reference method, and seed averaging.
+
+## License
+
+Apache-2.0. See the `LICENSE` file shipped with the distribution.

--- a/packages/bencheval/pyproject.toml
+++ b/packages/bencheval/pyproject.toml
@@ -1,13 +1,28 @@
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "bencheval"
-version = "0.0.1"
-requires-python = ">=3.10,<3.14"
-license = { text = "Apache-2.0" }
+version = "0.1.0"  # keep equal to packages/tabarena/pyproject.toml; PyPI releases ship both at one version
+description = "Benchmark evaluation for tabular ML: Elo, win-rate, rank and improvability leaderboards (the engine behind TabArena)"
+readme = "README.md"
+license = "Apache-2.0"
 authors = [{ name = "AutoGluon Community" }]
+requires-python = ">=3.10,<3.14"
+keywords = ["benchmark", "leaderboard", "elo", "tabular", "machine-learning", "tabarena"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
     "scipy",
     "numpy",
@@ -27,13 +42,14 @@ plot = [
     "plotly>=6.3.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/autogluon/tabarena"
+Repository = "https://github.com/autogluon/tabarena"
+Issues = "https://github.com/autogluon/tabarena/issues"
+"TabArena Leaderboard" = "https://tabarena.ai/"
+
+# LICENSE is not in this directory: scripts/release/build_pypi_dists.py copies the repository's
+# LICENSE next to this file when building for PyPI (setuptools picks up LICENSE* automatically).
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["bencheval*"]
-
-#[tool.setuptools]
-#package-dir = {}
-#packages = ["bencheval"]
-
-[project.urls]
-Homepage = "https://github.com/autogluon/tabarena"

--- a/packages/tabarena/pyproject.toml
+++ b/packages/tabarena/pyproject.toml
@@ -4,8 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tabarena"
-version = "0.0.1"
+version = "0.1.0"  # keep equal to packages/bencheval/pyproject.toml; PyPI releases ship both at one version
 description = "A Living Benchmark for Machine Learning on Tabular Data"
+# README.md and LICENSE are not in this directory: scripts/release/build_pypi_dists.py copies the
+# repository's README.md (links made absolute) and LICENSE next to this file when building for PyPI.
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "TabArena Community" }]
@@ -62,6 +64,11 @@ dependencies = [
 
 [project.optional-dependencies]
 
+# Requirements with a direct URL (`name @ git+https://...`) install from a git checkout but cannot
+# be published to PyPI. `scripts/release/build_pypi_dists.py` strips them from the PyPI build, which
+# leaves that extra empty on PyPI; the model's `pip_extra` in its `info.py` keeps the exact git
+# dependency for the install hint. Use a PyPI release whenever the upstream package has one.
+
 # Plotting / leaderboard visualization (the `tabarena.plot` modules + bencheval plots).
 # All plotting imports are lazy, so the core install never requires these.
 plot = [
@@ -89,7 +96,7 @@ data-foundry = ["data-foundry>=0.0.3"]
 # Core model extras — installed together via the `benchmark` union below.
 tabpfn = [
   "tabpfn>=8.0.8",
-  "tabpfn-extensions[many_class] @ git+https://github.com/PriorLabs/tabpfn-extensions.git",
+  "tabpfn-extensions[many_class]>=0.6.1",
 ]
 tabicl = ["tabicl>=2.0.0"]
 ebm = ["autogluon.tabular[interpret]>=1.6,<1.7"]
@@ -101,12 +108,16 @@ tabm = ["torch", "tabm>=0.0.3", "rtdl_num_embeddings>=0.0.12"]
 # Extended model extras — opt-in individually or together via the `extended` union below.
 modernnca = ["category_encoders"]
 xrfm = ["xrfm[cu12]"]
+# sap-rpt-oss and tabfm stay pinned to the git commits used for the benchmark runs, so these two
+# extras are empty on PyPI (see the note at the top of this table).
 sap-rpt-oss = ["sap_rpt_oss @ git+https://github.com/SAP-samples/sap-rpt-1-oss.git@a323a0aff976fda4ac43c3196a92406de7689aaa"]
 # TabFM uses its PyTorch backend; the `[pytorch]` extra pulls `torch` for GPU/CPU execution.
 tabfm = ["tabfm[pytorch] @ git+https://github.com/google-research/tabfm.git@53f3fcfb8a3355f55c9fb49f04fbb62b8ba29109"]
 tabstar = ["tabstar==1.1.15"]
 perpetualboosting = ["perpetual"] # We used version 2.1.0
-orionmsp = ["tabtune @ git+https://github.com/Lexsi-Labs/TabTune.git"] # from main to get newest code
+# The benchmark runs installed TabTune from git main (kept as `pip_extra` in models/orionmsp/info.py);
+# 0.1.18 is the PyPI release that ships the `orionmsp_v15` modules the wrapper imports.
+orionmsp = ["tabtune==0.1.18"]
 probmetrics = [
     "probmetrics",
     "pytorch-minimize",
@@ -119,8 +130,8 @@ tabpfnwide = ["tabpfnwide>=0.3.0"]
 iltm = ["iltm>=0.1.1"]
 chimeraboost = ["chimeraboost>=0.30.0"]
 nori = ["synthefy-nori>=0.10.0"]
-# EXAONE Tabular is not published on PyPI; pinned to a commit so the benchmarked code is fixed.
-# Keep in sync with `pip_extra` in models/exaone_tabular/info.py.
+# EXAONE Tabular is not published on PyPI; pinned to a commit so the benchmarked code is fixed
+# (empty extra on PyPI). Keep in sync with `pip_extra` in models/exaone_tabular/info.py.
 exaone_tabular = [
   "exaonetabular @ git+https://github.com/LGAI-Research/EXAONE-Tabular.git@cf55bd2d74aeb9c0b5d5d4f509d05831251a827e",
 ]
@@ -174,6 +185,11 @@ all = [
 
 [project.urls]
 Homepage = "https://github.com/autogluon/tabarena"
+Leaderboard = "https://tabarena.ai/"
+Repository = "https://github.com/autogluon/tabarena"
+Issues = "https://github.com/autogluon/tabarena/issues"
+"Paper (TabArena)" = "https://arxiv.org/abs/2506.16791"
+"Paper (BeyondArena)" = "https://arxiv.org/abs/2606.30410"
 
 # PEP 735 dependency groups: dev-only tools, not shipped in the wheel.
 # Install with: `uv sync --group dev`  (or `--group lint`, `--group test`).
@@ -191,14 +207,16 @@ include-package-data = true
 where = ["src"]
 include = ["tabarena*"]
 
+# Non-Python files shipped in the wheel, matched recursively so vendored models (configs, licenses)
+# are picked up wherever they live. `scripts/release/build_pypi_dists.py` fails the build when a
+# git-tracked non-.py file under src/ is missing from the wheel. Compiled `.so` files are not
+# shipped: the C++ metrics compile on first use from the shipped sources.
 [tool.setuptools.package-data]
 tabarena = [
-  "metrics/_cpp_metrics/compile.sh",
-  "metrics/_cpp_metrics/cpp_metrics.cpp",
-  "benchmark/task/metadata/data/curated_tabarena_dataset_metadata.csv",
-  "benchmark/task/metadata/sources/data/*.csv",
-  "contexts/beyondarena/data/*.csv",
-  "benchmark/models/ag/limix/_vendor/config/*.json",
-  "benchmark/models/ag/limix/_vendor/LICENSE.txt",
-  "benchmark/models/ag/limix/_vendor/README.md",
+  "**/*.csv",
+  "**/*.json",
+  "**/*.sh",
+  "**/*.cpp",
+  "**/*.md",
+  "**/LICENSE*",
 ]

--- a/scripts/release/build_pypi_dists.py
+++ b/scripts/release/build_pypi_dists.py
@@ -1,0 +1,299 @@
+"""Build the PyPI distributions of ``bencheval`` and ``tabarena``.
+
+The pyproject files in the repository describe the git-based install, which stays the recommended
+way to use TabArena. A PyPI build differs in a few controlled ways. They are applied to a staged
+copy of each package under a temporary directory, so the checkout itself is never modified:
+
+1. Both packages receive the same version, and ``tabarena`` pins ``bencheval==<version>``, so a
+   PyPI release is always a matching pair.
+2. Requirements with a direct URL (``name @ git+https://...``) are removed from ``tabarena``'s
+   extras because PyPI rejects distributions that carry them. The extra itself stays, empty. The
+   model's ``pip_extra`` in its ``info.py`` still names the exact git dependency, so the install
+   hint users see is unchanged.
+3. The root ``README.md`` (relative links rewritten to absolute GitHub URLs) and ``LICENSE`` are
+   copied next to ``tabarena``'s pyproject, and ``LICENSE`` next to ``bencheval``'s, so the wheels
+   carry a description and a license file without duplicating either file in git.
+
+After building, every wheel is checked: no direct URLs, a non-empty description, a license file,
+matching versions, the ``bencheval`` pin, and every git-tracked non-Python file under ``src/``
+present in the wheel.
+
+Usage, from the repository root (``uv`` must be on PATH)::
+
+    python scripts/release/build_pypi_dists.py                     # version from pyproject
+    python scripts/release/build_pypi_dists.py --version 0.1.0a1   # explicit version
+    python scripts/release/build_pypi_dists.py --dev               # <next patch>.dev<UTC timestamp>
+    python scripts/release/build_pypi_dists.py --check-tag v0.1.0  # fail unless pyproject == tag
+
+Distributions land in ``dist/`` (``--out-dir``). The GitHub workflows ``release.yml``,
+``prerelease.yml`` and ``dev-release.yml`` call this script and then run ``uv publish``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGES = ("bencheval", "tabarena")
+GITHUB_BLOB_URL = "https://github.com/autogluon/tabarena/blob/main/"
+
+# The `[project]` version line, keeping any trailing comment (`version = "0.1.0"  # keep equal to ...`).
+_VERSION_LINE_RE = re.compile(r'^version = "(?P<version>[^"]+)"(?P<rest>[ \t]*(?:#[^\n]*)?)$', re.MULTILINE)
+_PEP440_RE = re.compile(r"^\d+(\.\d+)*((a|b|rc)\d+)?(\.post\d+)?(\.dev\d+)?$")
+_PRERELEASE_RE = re.compile(r"(a|b|rc|\.dev)\d+$")
+_PLAIN_RELEASE_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+# A double-quoted requirement string with a direct URL, plus the comma that follows it (if any).
+# Works for one-per-line arrays and for inline arrays such as `tabfm = ["tabfm @ git+..."]`.
+_DIRECT_URL_TOKEN_RE = re.compile(r'"(?P<req>[^"\n]+ @ [^"\n]+)"[ \t]*,?')
+_BENCHEVAL_REQ_RE = re.compile(r'"bencheval(?P<extras>\[[^\]]*\])?"')
+_MARKDOWN_LINK_RE = re.compile(r"(?P<prefix>\]\()(?P<target>[^)\s]+)")
+_GITHUB_ALERT_RE = re.compile(r"^> \[!(?P<kind>NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]", re.MULTILINE)
+
+
+def set_version(pyproject_text: str, version: str) -> str:
+    """Return ``pyproject_text`` with its single ``[project]`` ``version`` line set to ``version``."""
+    matches = list(_VERSION_LINE_RE.finditer(pyproject_text))
+    if len(matches) != 1:
+        raise SystemExit(f"expected exactly one top-level `version = ...` line, found {len(matches)}")
+    return _VERSION_LINE_RE.sub(rf'version = "{version}"\g<rest>', pyproject_text)
+
+
+def pin_bencheval(pyproject_text: str, version: str) -> str:
+    """Pin every ``bencheval`` / ``bencheval[extra]`` requirement to ``==version``."""
+    text, n = _BENCHEVAL_REQ_RE.subn(lambda m: f'"bencheval{m.group("extras") or ""}=={version}"', pyproject_text)
+    if n == 0:
+        raise SystemExit("no `bencheval` requirement found to pin")
+    return text
+
+
+def strip_direct_url_requirements(pyproject_text: str) -> tuple[str, list[str]]:
+    """Remove requirement strings with a direct URL (``name @ url``) and return them.
+
+    A TOML parse afterwards verifies that no direct URL survives, which also catches requirement
+    strings written in a form the regex does not handle (e.g. single-quoted literal strings).
+    """
+    removed = [m.group("req") for m in _DIRECT_URL_TOKEN_RE.finditer(pyproject_text)]
+    text = _DIRECT_URL_TOKEN_RE.sub("", pyproject_text)
+    leftover = [req for req in _all_requirements(text) if " @ " in req]
+    if leftover:
+        raise SystemExit(f"direct-URL requirements survived stripping (unexpected TOML layout): {leftover}")
+    return text, removed
+
+
+def _all_requirements(pyproject_text: str) -> list[str]:
+    project = tomllib.loads(pyproject_text)["project"]
+    reqs = list(project.get("dependencies", []))
+    for extra_reqs in project.get("optional-dependencies", {}).values():
+        reqs.extend(extra_reqs)
+    return reqs
+
+
+def rewrite_readme_for_pypi(readme_text: str, base_url: str = GITHUB_BLOB_URL) -> str:
+    """Make the GitHub README render on PyPI: absolute link targets and plain alert blockquotes."""
+
+    def _absolutize(match: re.Match) -> str:
+        target = match.group("target")
+        if target.startswith(("http://", "https://", "mailto:", "#")):
+            return match.group(0)
+        return f"{match.group('prefix')}{base_url}{target.removeprefix('./')}"
+
+    text = _MARKDOWN_LINK_RE.sub(_absolutize, readme_text)
+    return _GITHUB_ALERT_RE.sub(lambda m: f"> **{m.group('kind').title()}**", text)
+
+
+def compute_dev_version(base_version: str, now: datetime | None = None) -> str:
+    """``X.Y.(Z+1).dev<UTC timestamp>``: sorts after ``X.Y.Z``, before ``X.Y.(Z+1)``, monotonic across commits."""
+    match = _PLAIN_RELEASE_RE.match(base_version)
+    if match is None:
+        raise SystemExit(f"pyproject version {base_version!r} is not a plain X.Y.Z; refusing to derive a dev version")
+    major, minor, patch = (int(part) for part in match.groups())
+    stamp = (now or datetime.now(UTC)).strftime("%Y%m%d%H%M%S")
+    return f"{major}.{minor}.{patch + 1}.dev{stamp}"
+
+
+def prepare_pyproject_text(package: str, pyproject_text: str, version: str) -> tuple[str, list[str]]:
+    """Apply the PyPI-build edits for ``package`` and return the new text plus the stripped requirements."""
+    text = set_version(pyproject_text, version)
+    removed: list[str] = []
+    if package == "tabarena":
+        text = pin_bencheval(text, version)
+        text, removed = strip_direct_url_requirements(text)
+    return text, removed
+
+
+def repo_version() -> str:
+    """The version shared by both pyproject files; fails if they disagree."""
+    versions = {
+        package: tomllib.loads((REPO_ROOT / "packages" / package / "pyproject.toml").read_text())["project"]["version"]
+        for package in PACKAGES
+    }
+    if len(set(versions.values())) != 1:
+        raise SystemExit(f"package versions must match, got {versions}")
+    return next(iter(versions.values()))
+
+
+def stage_package(package: str, stage_root: Path, version: str) -> Path:
+    """Copy ``packages/<package>`` into ``stage_root`` and apply the PyPI-build edits to the copy."""
+    pkg_dir = stage_root / package
+    shutil.copytree(
+        REPO_ROOT / "packages" / package,
+        pkg_dir,
+        ignore=shutil.ignore_patterns("*.egg-info", "__pycache__", "*.so", "build", "dist"),
+    )
+    pyproject = pkg_dir / "pyproject.toml"
+    text, removed = prepare_pyproject_text(package, pyproject.read_text(), version)
+    pyproject.write_text(text)
+    for req in removed:
+        print(f"  [{package}] stripped direct-URL requirement: {req}")
+    shutil.copy(REPO_ROOT / "LICENSE", pkg_dir / "LICENSE")
+    if package == "tabarena":
+        (pkg_dir / "README.md").write_text(rewrite_readme_for_pypi((REPO_ROOT / "README.md").read_text()))
+    return pkg_dir
+
+
+def build_package(pkg_dir: Path, out_dir: Path) -> None:
+    """Run ``uv build`` for a staged package; the build log is shown only on failure."""
+    cmd = ["uv", "build", str(pkg_dir), "--out-dir", str(out_dir)]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)  # noqa: S603
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout + result.stderr)
+        raise SystemExit(f"`{' '.join(cmd)}` failed with exit code {result.returncode}")
+
+
+def wheel_metadata(wheel: Path) -> tuple[dict[str, list[str]], str]:
+    """Return the wheel's METADATA as (header fields, each a list of values; long-description body)."""
+    with zipfile.ZipFile(wheel) as zf:
+        name = next(n for n in zf.namelist() if n.endswith(".dist-info/METADATA"))
+        raw = zf.read(name).decode()
+    header, _, body = raw.partition("\n\n")
+    fields: dict[str, list[str]] = {}
+    for line in header.splitlines():
+        key, _, value = line.partition(": ")
+        fields.setdefault(key, []).append(value)
+    return fields, body
+
+
+def tracked_data_files(package: str) -> list[str] | None:
+    """Git-tracked non-``.py`` files under ``src/<package>`` as wheel-relative paths; None if git is unavailable."""
+    src_root = Path("packages") / package / "src"
+    result = subprocess.run(  # noqa: S603
+        ["git", "ls-files", "--", str(src_root / package)],  # noqa: S607
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return [
+        Path(line).relative_to(src_root).as_posix()
+        for line in result.stdout.splitlines()
+        if line and not line.endswith(".py")
+    ]
+
+
+def check_wheel(wheel: Path, package: str, version: str, tracked_files: list[str] | None) -> None:
+    """Fail with a readable list of problems if ``wheel`` is not fit for PyPI."""
+    fields, body = wheel_metadata(wheel)
+    problems: list[str] = []
+    if fields.get("Version") != [version]:
+        problems.append(f"Version is {fields.get('Version')}, expected [{version!r}]")
+    requires = fields.get("Requires-Dist", [])
+    if direct := [req for req in requires if " @ " in req]:
+        problems.append(f"direct-URL requirements (PyPI rejects these): {direct}")
+    if not body.strip():
+        problems.append("empty long description (README not staged?)")
+    if not fields.get("License-File"):
+        problems.append("no License-File (LICENSE not staged?)")
+    if package == "tabarena":
+        bad_pins = [req for req in requires if req.startswith("bencheval") and f"=={version}" not in req]
+        if bad_pins:
+            problems.append(f"bencheval not pinned to =={version}: {bad_pins}")
+    if tracked_files is not None:
+        with zipfile.ZipFile(wheel) as zf:
+            shipped = set(zf.namelist())
+        if missing := sorted(set(tracked_files) - shipped):
+            problems.append(f"git-tracked data files missing from the wheel (fix package-data): {missing}")
+    if problems:
+        raise SystemExit(f"{wheel.name} is not publishable:\n  - " + "\n  - ".join(problems))
+
+
+def verify_dists(out_dir: Path, version: str) -> list[Path]:
+    """Check that ``out_dir`` holds one wheel and one sdist per package and that every wheel passes."""
+    files: list[Path] = []
+    for package in PACKAGES:
+        wheels = sorted(out_dir.glob(f"{package}-*.whl"))
+        sdists = sorted(out_dir.glob(f"{package}-*.tar.gz"))
+        if len(wheels) != 1 or len(sdists) != 1:
+            raise SystemExit(f"expected one wheel and one sdist for {package} in {out_dir}, found {wheels + sdists}")
+        check_wheel(wheels[0], package, version, tracked_data_files(package))
+        files.extend([*wheels, *sdists])
+    return files
+
+
+def resolve_version(args: argparse.Namespace) -> str:
+    base = repo_version()
+    if args.version:
+        if not _PEP440_RE.match(args.version):
+            raise SystemExit(f"{args.version!r} is not a canonical PEP 440 version (e.g. 0.1.0, 0.1.0a1, 0.1.0.dev3)")
+        version = args.version
+    elif args.dev:
+        version = compute_dev_version(base)
+    else:
+        version = base
+        if args.check_tag is not None and args.check_tag.removeprefix("v") != base:
+            raise SystemExit(f"tag {args.check_tag} does not match the pyproject version {base}")
+    if args.require_prerelease and not _PRERELEASE_RE.search(version):
+        raise SystemExit(f"{version!r} has no pre-release segment; use the Release workflow (tag v{version}) instead")
+    return version
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0], formatter_class=argparse.RawTextHelpFormatter
+    )
+    how = parser.add_mutually_exclusive_group()
+    how.add_argument("--version", help="explicit version for both packages (the pyproject files are not modified)")
+    how.add_argument(
+        "--dev", action="store_true", help="derive <next patch>.dev<UTC timestamp> from the pyproject version"
+    )
+    how.add_argument(
+        "--check-tag", metavar="TAG", help="use the pyproject version; fail unless it equals TAG (v prefix ok)"
+    )
+    parser.add_argument(
+        "--require-prerelease", action="store_true", help="fail if the resolved version is a stable release"
+    )
+    parser.add_argument(
+        "--out-dir", type=Path, default=REPO_ROOT / "dist", help="where to write the dists (default: dist/)"
+    )
+    args = parser.parse_args(argv)
+
+    version = resolve_version(args)
+    out_dir = args.out_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for stale in [p for package in PACKAGES for p in out_dir.glob(f"{package}-*")]:
+        print(f"  removing stale {stale.name}")
+        stale.unlink()
+
+    print(f"Building bencheval + tabarena {version} into {out_dir}")
+    with tempfile.TemporaryDirectory(prefix="tabarena-pypi-") as tmp:
+        for package in PACKAGES:
+            build_package(stage_package(package, Path(tmp), version), out_dir)
+    files = verify_dists(out_dir, version)
+    print("Built and verified:")
+    for f in files:
+        print(f"  {f.relative_to(out_dir)}")
+    print(f"version={version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/release/__init__.py
+++ b/tests/release/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/release/test_build_pypi_dists.py
+++ b/tests/release/test_build_pypi_dists.py
@@ -1,0 +1,143 @@
+"""Tests for ``scripts/release/build_pypi_dists.py``: the pyproject edits and the wheel checks.
+
+Nothing here runs ``uv build``; the full build is exercised by the ``install-from-wheel`` CI job.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tomllib
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "release" / "build_pypi_dists.py"
+
+
+@pytest.fixture(scope="module")
+def build():
+    spec = importlib.util.spec_from_file_location("build_pypi_dists", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+TOML = """[project]
+name = "tabarena"
+version = "0.0.1"  # keep equal to bencheval
+dependencies = [
+  "bencheval",
+  "numpy",
+]
+
+[project.optional-dependencies]
+plot = ["bencheval[plot]", "tueplots"]
+tabpfn = [
+  "tabpfn>=8.0.8",
+  "tabpfn-extensions[many_class] @ git+https://github.com/PriorLabs/tabpfn-extensions.git",
+]
+tabfm = ["tabfm[pytorch] @ git+https://github.com/google-research/tabfm.git@53f3fcf"]  # pinned commit
+mixed = ["einops", "sap_rpt_oss @ git+https://github.com/SAP-samples/sap-rpt-1-oss.git@a323a0a"]
+tabswift = []
+"""
+
+
+def test_set_version_replaces_only_the_project_version(build):
+    out = build.set_version(TOML, "0.1.0a1")
+    assert tomllib.loads(out)["project"]["version"] == "0.1.0a1"
+    assert "0.0.1" not in out
+    assert 'version = "0.1.0a1"  # keep equal to bencheval' in out
+
+
+def test_pin_bencheval_covers_plain_and_extra_requirements(build):
+    project = tomllib.loads(build.pin_bencheval(TOML, "0.1.0a1"))["project"]
+    assert "bencheval==0.1.0a1" in project["dependencies"]
+    assert "bencheval[plot]==0.1.0a1" in project["optional-dependencies"]["plot"]
+
+
+def test_strip_direct_url_requirements_empties_extras_but_keeps_them(build):
+    text, removed = build.strip_direct_url_requirements(TOML)
+    extras = tomllib.loads(text)["project"]["optional-dependencies"]
+    assert removed == [
+        "tabpfn-extensions[many_class] @ git+https://github.com/PriorLabs/tabpfn-extensions.git",
+        "tabfm[pytorch] @ git+https://github.com/google-research/tabfm.git@53f3fcf",
+        "sap_rpt_oss @ git+https://github.com/SAP-samples/sap-rpt-1-oss.git@a323a0a",
+    ]
+    assert extras["tabpfn"] == ["tabpfn>=8.0.8"]
+    assert extras["tabfm"] == []
+    assert extras["mixed"] == ["einops"]
+    assert extras["tabswift"] == []
+    assert "# pinned commit" in text
+
+
+def test_strip_direct_url_requirements_rejects_unhandled_layout(build):
+    literal = '[project]\nname = "x"\nversion = "0.0.1"\ndependencies = [\'a @ git+https://e.com/a.git\']\n'
+    with pytest.raises(SystemExit, match="survived"):
+        build.strip_direct_url_requirements(literal)
+
+
+def test_compute_dev_version(build):
+    stamp = datetime(2026, 9, 3, 10, 2, 33, tzinfo=UTC)
+    assert build.compute_dev_version("0.1.0", now=stamp) == "0.1.1.dev20260903100233"
+    with pytest.raises(SystemExit, match="plain X.Y.Z"):
+        build.compute_dev_version("0.1.0a1")
+
+
+def test_rewrite_readme_for_pypi(build):
+    readme = (
+        "See [examples](examples/plots), [docs](./tabrepo.md), [site](https://tabarena.ai/), [top](#-installation).\n"
+        "> [!TIP]\n> Tip body\n"
+    )
+    out = build.rewrite_readme_for_pypi(readme, base_url="https://gh/blob/main/")
+    assert "[examples](https://gh/blob/main/examples/plots)" in out
+    assert "[docs](https://gh/blob/main/tabrepo.md)" in out
+    assert "[site](https://tabarena.ai/)" in out
+    assert "[top](#-installation)" in out
+    assert "> **Tip**\n> Tip body" in out
+
+
+def test_repo_pyproject_files_are_publishable_after_preparation(build):
+    """Run the real pyproject files through the PyPI edits; this is what the release workflows publish."""
+    for package in build.PACKAGES:
+        text = (REPO_ROOT / "packages" / package / "pyproject.toml").read_text()
+        prepared, _ = build.prepare_pyproject_text(package, text, "0.1.0a1")
+        project = tomllib.loads(prepared)["project"]
+        assert project["version"] == "0.1.0a1"
+        all_reqs = [*project["dependencies"], *(r for reqs in project["optional-dependencies"].values() for r in reqs)]
+        assert not [r for r in all_reqs if " @ " in r]
+        if package == "tabarena":
+            bencheval_reqs = [r for r in all_reqs if r.startswith("bencheval")]
+            assert bencheval_reqs
+            assert all("==0.1.0a1" in r for r in bencheval_reqs)
+
+
+def _fake_wheel(path: Path, metadata: str, extra_files: tuple[str, ...] = ()) -> Path:
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("pkg-1.0.dist-info/METADATA", metadata)
+        for name in extra_files:
+            zf.writestr(name, "")
+    return path
+
+
+def test_check_wheel_accepts_a_good_wheel_and_reports_every_problem(build, tmp_path):
+    good_metadata = (
+        "Metadata-Version: 2.4\nName: tabarena\nVersion: 0.1.0a1\nLicense-File: LICENSE\n"
+        'Requires-Dist: bencheval==0.1.0a1\nRequires-Dist: bencheval[plot]==0.1.0a1; extra == "plot"\n'
+        "\nLong description\n"
+    )
+    good = _fake_wheel(tmp_path / "tabarena-0.1.0a1-py3-none-any.whl", good_metadata, ("tabarena/data/x.csv",))
+    build.check_wheel(good, "tabarena", "0.1.0a1", ["tabarena/data/x.csv"])
+
+    bad_metadata = (
+        "Metadata-Version: 2.4\nName: tabarena\nVersion: 0.1.0a1\n"
+        'Requires-Dist: bencheval\nRequires-Dist: tabfm @ git+https://x/y.git ; extra == "tabfm"\n\n'
+    )
+    bad = _fake_wheel(tmp_path / "bad.whl", bad_metadata)
+    with pytest.raises(SystemExit) as info:
+        build.check_wheel(bad, "tabarena", "0.1.0a1", ["tabarena/data/x.csv"])
+    message = str(info.value)
+    for expected in ("direct-URL", "empty long description", "no License-File", "bencheval not pinned", "missing from"):
+        assert expected in message


### PR DESCRIPTION
Closes #495 once the first pre-release is published.

## Summary

Adds everything needed to publish `bencheval` and `tabarena` to PyPI as an **experimental** copy of the git-based install, which stays the recommended way to use TabArena. Downstream packages (RamanBench in #495) can then depend on both without git URLs.

The setup mirrors [TabArena/data-foundry](https://github.com/TabArena/data-foundry): three workflows (`release.yml` on a `v*` tag, `prerelease.yml` from the Actions UI, `dev-release.yml` on every green push to `main`), no version ever committed by CI, one shared version for both packages.

## What a PyPI build changes, and why

`scripts/release/build_pypi_dists.py` builds both packages from a **staged copy** (the checkout is never modified), then verifies the wheels. Compared to the repo's pyproject files it:

- sets one version on both packages and pins `bencheval==<version>` in `tabarena`, so a release is always a matching pair (AutoGluon-style lockstep);
- strips requirements with a direct URL (`name @ git+...`). PyPI rejects any distribution carrying them, which is exactly the error reported in #495. The repo keeps the git pins for `tabfm`, `sap-rpt-oss` and `exaone_tabular`, so the git-based install is unchanged; on PyPI those three extras are empty and the model's `pip_extra` install hint still names the exact git dependency;
- copies the root `README.md` (relative links rewritten to absolute GitHub URLs, GitHub alerts to plain blockquotes) and `LICENSE` next to each pyproject. Neither file is duplicated in git; setuptools refuses `../../LICENSE` paths, so a build-time copy is the closest to "reference, don't copy".

The verification fails the build on a leftover direct URL, an empty description, a missing license file, a wrong `bencheval` pin, or any git-tracked non-`.py` file under `src/` that the package-data globs missed. That last check would have caught the LiMiX bug below.

## Fixes surfaced by building a wheel

- `tabarena`'s package-data globs pointed at `benchmark/models/ag/limix/...`, a path that no longer exists, so wheels shipped no LiMiX config JSON and no vendored LICENSE files. Editable installs hide this. Replaced by recursive globs (`**/*.csv`, `**/*.json`, `**/*.sh`, `**/*.cpp`, `**/*.md`, `**/LICENSE*`).
- Both wheels had an empty long description and no license file (`readme = "README.md"` pointed at a file that does not exist in `packages/tabarena/`; `bencheval` declared none). `bencheval` now has its own short README; `tabarena` uses the repo README via the staging step.
- `bencheval` used the deprecated `license = { text = ... }` table; now `license = "Apache-2.0"` + `setuptools>=77`, plus description, keywords, classifiers, URLs.

## Dependency changes (please confirm)

| Extra | Before | After | Note |
|---|---|---|---|
| `tabpfn` | `tabpfn-extensions[many_class] @ git main` | `tabpfn-extensions[many_class]>=0.6.1` | 0.6.1 was released from the commit git main resolves to; `many_class` has no extra deps |
| `orionmsp` | `tabtune @ git main` | `tabtune==0.1.18` | verified the wheel ships `tabtune.models.orionmsp_v15.{sklearn.classifier,model.embedding}`; `info.py` `pip_extra` keeps the git URL |
| `tabfm`, `sap-rpt-oss`, `exaone_tabular` | git commit | unchanged (stripped on PyPI only) | as discussed |

`version` in both pyproject files goes `0.0.1` to `0.1.0`. With data-foundry's scheme the pyproject holds the *upcoming* stable version, so the first pre-release is `0.1.0a1` and dev builds are `0.1.1.dev<timestamp>` (which sort above the alpha, so `pip install --pre tabarena` tracks `main`). Happy to keep `0.0.1` instead if you prefer; then the dev builds would sort below `0.1.0a1`.

`--prerelease=allow` stays in all docs as requested.

## One-time setup before the first publish (documented in AGENTS.md)

Trusted publishing (OIDC) is used instead of a stored token, so `uv publish --trusted-publishing always` fails with an OIDC error until this is done:

1. **PyPI, project owner** (@LennartPurucker owns `tabarena` 0.0.0): for each of `tabarena` and `bencheval`, add a trusted publisher per workflow file (`release.yml`, `prerelease.yml`, `dev-release.yml`) with owner `autogluon`, repository `tabarena`, environment `pypi`. `bencheval` is not on PyPI yet, so add it as a *pending* publisher (reserves the name until the first upload).
2. **GitHub `pypi` environment**: created automatically on the first run that references it. Protection rules (required reviewers, tag-only deployments) need repo admin rights, which maintainers with push access do not have; that needs an `autogluon` org admin.

Then: Actions -> "Prerelease (PyPI)" -> Run workflow -> `0.1.0a1` (or `gh workflow run prerelease.yml -f version=0.1.0a1`).

## Verification

- `pytest tests/release` (8 tests: version/pin/strip edits, README rewrite, dev version, wheel checks, and the real pyproject files run through the PyPI edits).
- `python scripts/release/build_pypi_dists.py --version 0.1.0a1` builds and verifies all four distributions locally (three requirements stripped, all tracked data files present, `License-File`, absolute README links).
- Installed the built wheels non-editable into a fresh venv with `tabarena[plot]`: imports from `site-packages`, LiMiX configs / metadata CSVs / C++ metric sources present, no heavy optional deps leaked, and the `bencheval` README snippet runs.
- `ruff check` + `ruff format --check` on the new files; all workflow YAML parses.

Not verified here: an actual `uv publish` (needs the trusted-publisher setup above). The `install-from-wheel` CI job added to `install-benchmark.yml` will run the build + verify + clean install on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
