### PR TITLE
Attach only wheels and sdists to the GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*
+          # Only the distributions: `uv build` also writes a `.gitignore` into dist/.
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
           generate_release_notes: true
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
Follow-up to #507. `uv build` writes a `.gitignore` into `dist/`, so `files: dist/*` in `release.yml` uploaded it to the v0.1.0 GitHub Release as `default.gitignore` (already deleted from that release by hand). The glob now matches only `dist/*.whl` and `dist/*.tar.gz`. `uv publish dist/*` was unaffected: uv only uploads distribution files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)