### PR TITLE
Pin HF checkpoint revisions for limix, tabswift, orionmsp, sap_rpt_oss, tabdpt

### DIFF
--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -124,6 +124,7 @@ The AutoGluon wrapper class. Use the template in `references/model_patterns.md` 
 - Docstring must include: description, paper title, authors, codebase URL, license
 - Keep optional third-party imports (the wrapped library itself) inside `_fit` / per-method scope so importing this module never requires the optional dep at top-level
 - Decide the model's untimed **warm-up** (Step 3g) while you have the library docs in hand
+- **Foundation model with Hugging Face weights: always pin `revision=`** on every `hf_hub_download`/`snapshot_download` call — never resolve against the repo's moving default branch. See `references/model_patterns.md` → "Foundation-model weights: always pin the HF checkpoint revision" for the template and how to resolve the commit.
 
 ### 3c. `packages/tabarena/src/tabarena/models/{ModelKey}/hpo.py`
 

--- a/.claude/skills/add-model/references/model_patterns.md
+++ b/.claude/skills/add-model/references/model_patterns.md
@@ -416,6 +416,55 @@ one-time work to the first `_predict` (put it in `_fit` or `warmup`).
 
 ---
 
+## Foundation-model weights: always pin the HF checkpoint revision
+
+Any foundation model whose weights come from Hugging Face (`hf_hub_download` /
+`snapshot_download`) must pin `revision=` to a specific commit — never resolve against the repo's
+current default branch. Without it, a push to the HF repo silently changes the weights every
+subsequent fit uses, with nothing in this repo recording that it happened (see
+autogluon/tabarena#510 for the incident that prompted this).
+
+```python
+_DEFAULT_HF_REPO = "SomeOrg/SomeModel"
+_DEFAULT_HF_FILENAME = "checkpoint.safetensors"
+#: Commit pinned so the checkpoint fetched here never silently changes if the
+#: repo's default branch moves. Bump deliberately (with a note on what changed)
+#: when picking up a newer checkpoint.
+_DEFAULT_HF_REVISION = "<commit-sha-from-huggingface.co/api/models/{repo}>"
+
+
+@classmethod
+def prefetch_weights(cls) -> str:
+    """Pre-download the checkpoint from Hugging Face and return its local path.
+
+    Tries the local cache first so offline compute nodes skip the etag
+    HEAD-request that ``hf_hub_download`` performs by default.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    try:
+        return hf_hub_download(
+            repo_id=_DEFAULT_HF_REPO,
+            filename=_DEFAULT_HF_FILENAME,
+            revision=_DEFAULT_HF_REVISION,
+            local_files_only=True,
+        )
+    except LocalEntryNotFoundError:
+        return hf_hub_download(
+            repo_id=_DEFAULT_HF_REPO,
+            filename=_DEFAULT_HF_FILENAME,
+            revision=_DEFAULT_HF_REVISION,
+        )
+```
+
+Resolve `_DEFAULT_HF_REVISION` from `https://huggingface.co/api/models/{repo_id}` (the `sha`
+field) at the time you write the wrapper, not by hand-guessing a commit. Wire this same
+classmethod into `ModelInfo(prefetch_weights=...)` in `info.py` so the foundation-model
+pre-download scripts (see the `benchmark-model` skill) pick it up.
+
+---
+
 ## Categorical & missing-value handling — prefer the library's native path
 
 A frequent review finding: wrappers needlessly label-encode categoricals, impute with `fillna(0)`,

--- a/packages/tabarena/src/tabarena/models/limix/model.py
+++ b/packages/tabarena/src/tabarena/models/limix/model.py
@@ -26,6 +26,10 @@ _CONFIG_DIR = _VENDOR_DIR / "config"
 
 _DEFAULT_HF_REPO = "stableai-org/LimiX-16M"
 _DEFAULT_HF_FILENAME = "LimiX-16M.ckpt"
+#: Commit pinned so the checkpoint fetched here never silently changes if the
+#: repo's default branch moves. Bump deliberately (with a note on what changed)
+#: when picking up a newer checkpoint.
+_DEFAULT_HF_REVISION = "da5f3072bf3633c70d957c02518c30d461007764"
 _DEFAULT_CLS_CONFIG = "cls_default_16M_retrieval.json"
 _DEFAULT_REG_CONFIG = "reg_default_16M_retrieval.json"
 
@@ -267,10 +271,15 @@ class LimiXModel(AbstractTorchModel):
             return hf_hub_download(
                 repo_id=_DEFAULT_HF_REPO,
                 filename=_DEFAULT_HF_FILENAME,
+                revision=_DEFAULT_HF_REVISION,
                 local_files_only=True,
             )
         except LocalEntryNotFoundError:
-            return hf_hub_download(repo_id=_DEFAULT_HF_REPO, filename=_DEFAULT_HF_FILENAME)
+            return hf_hub_download(
+                repo_id=_DEFAULT_HF_REPO,
+                filename=_DEFAULT_HF_FILENAME,
+                revision=_DEFAULT_HF_REVISION,
+            )
 
 
 def _load_bundled_config(filename: str) -> list:

--- a/packages/tabarena/src/tabarena/models/orionmsp/model.py
+++ b/packages/tabarena/src/tabarena/models/orionmsp/model.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 
 _HF_REPO_ID = "Lexsi/Orion-MSP"
 _DEFAULT_CHECKPOINT_FILE = "OrionMSP-classifier-v1.5-202603.ckpt"
+#: Commit pinned so checkpoints fetched here never silently change if the
+#: repo's default branch moves. Bump deliberately (with a note on what
+#: changed) when picking up newer checkpoints.
+_HF_REVISION = "8b712f6ff699750f7ac5825f31e89e6f6f161577"
 
 
 class OrionMSPModel(AbstractTorchModel):
@@ -147,7 +151,12 @@ def _resolve_checkpoint(filename: str, allow_auto_download: bool = True) -> str:
     from huggingface_hub.errors import LocalEntryNotFoundError
 
     try:
-        return hf_hub_download(repo_id=_HF_REPO_ID, filename=filename, local_files_only=True)
+        return hf_hub_download(
+            repo_id=_HF_REPO_ID,
+            filename=filename,
+            revision=_HF_REVISION,
+            local_files_only=True,
+        )
     except LocalEntryNotFoundError:
         if not allow_auto_download:
             raise ValueError(
@@ -161,7 +170,7 @@ def _resolve_checkpoint(filename: str, allow_auto_download: bool = True) -> str:
             filename,
             _HF_REPO_ID,
         )
-        return hf_hub_download(repo_id=_HF_REPO_ID, filename=filename)
+        return hf_hub_download(repo_id=_HF_REPO_ID, filename=filename, revision=_HF_REVISION)
 
 
 def prefetch_weights(filename: str = _DEFAULT_CHECKPOINT_FILE) -> str:

--- a/packages/tabarena/src/tabarena/models/sap_rpt_oss/model.py
+++ b/packages/tabarena/src/tabarena/models/sap_rpt_oss/model.py
@@ -115,8 +115,11 @@ class SAPRPTOSSModel(AbstractTorchModel):
 def prefetch_weights() -> None:
     from huggingface_hub import hf_hub_download
 
-    # Hardcoded to the checkpoint we use in TabArena.
+    # Hardcoded to the checkpoint we use in TabArena. Commit pinned so it never
+    # silently changes if the repo's default branch moves; bump deliberately
+    # (with a note on what changed) when picking up a newer checkpoint.
     hf_hub_download(
         repo_id="SAP/sap-rpt-1-oss",
         filename="2025-11-04_sap-rpt-one-oss.pt",
+        revision="bc2c99cc541eeac9d1e10ae79da192d38b9fb27b",
     )

--- a/packages/tabarena/src/tabarena/models/tabdpt/model.py
+++ b/packages/tabarena/src/tabarena/models/tabdpt/model.py
@@ -46,6 +46,10 @@ class TabDPTModelBase(AbstractTorchModel):
 
     #: Hugging Face repo hosting every TabDPT checkpoint.
     _hf_repo_id: ClassVar[str] = "Layer6/TabDPT"
+    #: Commit pinned so checkpoints fetched here never silently change if the
+    #: repo's default branch moves. Bump deliberately (with a note on what
+    #: changed) when picking up newer checkpoints.
+    _hf_revision: ClassVar[str] = "4462ffbd1d8dea25d4862d30beed4b70cd596ae5"
     #: This version's checkpoint filename in :attr:`_hf_repo_id`. The installed ``tabdpt`` package
     #: hardcodes a single version (``tabdpt<VER>.safetensors``), so we pin the correct weights per
     #: version explicitly via ``model_weight_path`` rather than relying on the package default —
@@ -137,10 +141,15 @@ class TabDPTModelBase(AbstractTorchModel):
             return hf_hub_download(
                 repo_id=cls._hf_repo_id,
                 filename=cls._checkpoint_filename,
+                revision=cls._hf_revision,
                 local_files_only=True,
             )
         except LocalEntryNotFoundError:
-            return hf_hub_download(repo_id=cls._hf_repo_id, filename=cls._checkpoint_filename)
+            return hf_hub_download(
+                repo_id=cls._hf_repo_id,
+                filename=cls._checkpoint_filename,
+                revision=cls._hf_revision,
+            )
 
     @classmethod
     def prefetch_weights(cls) -> str:

--- a/packages/tabarena/src/tabarena/models/tabswift/model.py
+++ b/packages/tabarena/src/tabarena/models/tabswift/model.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 _DEFAULT_HF_REPO = "LAMDA-Tabular/TabSwift"
 _DEFAULT_HF_FILENAME = "swift.ckpt"
 """A single ``swift.ckpt`` checkpoint serves both the classifier and the regressor."""
+#: Commit pinned so the checkpoint fetched here never silently changes if the
+#: repo's default branch moves. Bump deliberately (with a note on what changed)
+#: when picking up a newer checkpoint.
+_DEFAULT_HF_REVISION = "b829456edb7c41ad93a2851a8df245db362e1c83"
 
 
 class TabSwiftModel(AbstractTorchModel):
@@ -197,7 +201,12 @@ class TabSwiftModel(AbstractTorchModel):
             return hf_hub_download(
                 repo_id=_DEFAULT_HF_REPO,
                 filename=_DEFAULT_HF_FILENAME,
+                revision=_DEFAULT_HF_REVISION,
                 local_files_only=True,
             )
         except LocalEntryNotFoundError:
-            return hf_hub_download(repo_id=_DEFAULT_HF_REPO, filename=_DEFAULT_HF_FILENAME)
+            return hf_hub_download(
+                repo_id=_DEFAULT_HF_REPO,
+                filename=_DEFAULT_HF_FILENAME,
+                revision=_DEFAULT_HF_REVISION,
+            )


### PR DESCRIPTION
Just a suggestion — happy to close if you'd rather stay on the moving default branch.

Every `hf_hub_download`/`snapshot_download` call in these five models resolves against the repo's current default branch, with no `revision=` and no content hash. A push to any of these HF repos would silently change the weights a fit uses, with nothing in this repo recording that it happened.

This PR pins each to its current HEAD commit (fetched from the HF API just now), same pattern already used elsewhere in the codebase for git dependencies.

**Question for you:** is a fixed pin actually what you want here, or is tracking whatever the repo's default branch currently has intentional (e.g. so a checkpoint update upstream is picked up automatically without a tabarena PR)? If the latter, feel free to close this — wanted to flag the tradeoff rather than assume.

TabFM is deliberately **not** included — its own commit-pin mismatch between `pyproject.toml` (`53f3fcf`) and `tabfm/info.py` (`633cd26`) needs separate attention (633cd26 is newer and includes an upstream picklability fix, so it looks like the correct one, but wanted to raise that as its own thing rather than bundle it here).