### PR TITLE
Reconcile TabFM commit pin between pyproject.toml and tabfm/info.py

### DIFF
--- a/packages/tabarena/pyproject.toml
+++ b/packages/tabarena/pyproject.toml
@@ -112,7 +112,9 @@ xrfm = ["xrfm[cu12]"]
 # extras are empty on PyPI (see the note at the top of this table).
 sap-rpt-oss = ["sap_rpt_oss @ git+https://github.com/SAP-samples/sap-rpt-1-oss.git@a323a0aff976fda4ac43c3196a92406de7689aaa"]
 # TabFM uses its PyTorch backend; the `[pytorch]` extra pulls `torch` for GPU/CPU execution.
-tabfm = ["tabfm[pytorch] @ git+https://github.com/google-research/tabfm.git@53f3fcfb8a3355f55c9fb49f04fbb62b8ba29109"]
+# Pinned to the same commit as tabfm/info.py's ModelInfo.pip_extra, so `pip install`
+# and the model registry's own metadata agree on which estimator was tuned.
+tabfm = ["tabfm[pytorch] @ git+https://github.com/google-research/tabfm.git@633cd265f498e1d20c9625be0639f6305d8e2541"]
 tabstar = ["tabstar==1.1.15"]
 perpetualboosting = ["perpetual"] # We used version 2.1.0
 # The benchmark runs installed TabTune from git main (kept as `pip_extra` in models/orionmsp/info.py);


### PR DESCRIPTION
`pyproject.toml`'s `tabfm` extra pins `53f3fcf`, while `tabfm/info.py`'s `ModelInfo.pip_extra` (the metadata the model wrapper and search space were actually built against) pins `633cd26` — both added in the same commit (29df3d5, #505).

One line: bumps `pyproject.toml`'s pin to match `info.py`'s.

Split out from #510