### PR TITLE
Family-colored marker edges and more y room in the focus Pareto figures

### DIFF
--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_shared.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_shared.py
@@ -18,7 +18,7 @@ import html
 import json
 from typing import TYPE_CHECKING
 
-from tabarena.plot.plot_pareto_focus import FAMILY_COLORS
+from tabarena.plot.plot_pareto_focus import FAMILY_COLORS, marker_edge_color
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -35,8 +35,18 @@ _FAMILY_CSS_TOKENS: dict[str, str] = {
 
 
 def _family_css_vars() -> str:
-    """CSS custom-property lines carrying the shared family colors."""
-    return "\n".join(f"    {token}: {FAMILY_COLORS[family]};" for family, token in _FAMILY_CSS_TOKENS.items())
+    """CSS custom-property lines carrying the shared family colors.
+
+    ``--fam-<key>`` is the family color. ``--fam-<key>-edge`` is the edge an emphasized marker
+    draws on the light surface: the family color darkened as in the static figures. Dark mode
+    overrides the edge tokens.
+    """
+    lines = []
+    for family, token in _FAMILY_CSS_TOKENS.items():
+        color = FAMILY_COLORS[family]
+        lines.append(f"    {token}: {color};")
+        lines.append(f"    {token}-edge: {marker_edge_color(color, emphasized=True)};")
+    return "\n".join(lines)
 
 
 #: Theme tokens + the chrome (controls, chips, tooltip, data table) every
@@ -104,6 +114,14 @@ _DARK_TOKENS = """
     --fam-system-ink: var(--fam-system);
     --fam-baseline-ink: var(--fam-baseline);
     --fam-other-ink: var(--fam-other);
+    /* An emphasized marker's face already carries its family on the dark surface; its edge
+       only separates neighbours, so it takes the card color. */
+    --fam-foundation-edge: var(--card);
+    --fam-nn-edge: var(--card);
+    --fam-tree-edge: var(--card);
+    --fam-system-edge: var(--card);
+    --fam-baseline-edge: var(--card);
+    --fam-other-edge: var(--card);
     --var-default: #4386d5;
     --var-tuned: #c05f38;
     --var-tunedens: #289972;
@@ -127,11 +145,13 @@ def _scope(selector: str, *bodies: str, indent: str = "  ") -> str:
 #: Theme tokens + the chrome (controls, chips, tooltip, data table) every
 #: explorer shares. Chart-specific layout stays in the individual templates.
 #:
-#: Four scopes, in this order: the base (light) scope carries the family colors;
-#: the media query follows the OS preference; ``[data-theme="dark"]`` lets an
-#: embedding page force dark (the always-dark leaderboard Space does); and
-#: ``[data-theme="light"]`` forces light for the paper view, beating both the
-#: media query (lower specificity) and the dark stamp (same specificity, later).
+#: Four scopes, in this order: the base (light) scope carries the family colors
+#: and their marker-edge tokens; the media query follows the OS preference;
+#: ``[data-theme="dark"]`` lets an embedding page force dark (the always-dark
+#: leaderboard Space does); and ``[data-theme="light"]`` forces light for the
+#: paper view, beating both the media query (lower specificity) and the dark
+#: stamp (same specificity, later). It repeats the family tokens so the light
+#: edge tokens win there too.
 EXPLORER_BASE_CSS = "".join(
     [
         _scope(":root", "__FAMILY_CSS_VARS__", _LIGHT_TOKENS),
@@ -140,7 +160,7 @@ EXPLORER_BASE_CSS = "".join(
         "\n  }\n",
         _scope(':root[data-theme="dark"]', _DARK_TOKENS),
         "\n",
-        _scope(':root[data-theme="light"]', _LIGHT_TOKENS),
+        _scope(':root[data-theme="light"]', "__FAMILY_CSS_VARS__", _LIGHT_TOKENS),
         r"""
   html, body { margin: 0; background: var(--paper); }
   /* The colour emoji fonts are named *before* the generic `sans-serif`. A generic
@@ -336,6 +356,14 @@ EXPLORER_BASE_JS = r"""
     "Neural Network": "var(--fam-nn-ink)",
     "System": "var(--fam-system-ink)",
     [FAM_MERGED]: "var(--fam-baseline-ink)",
+  };
+  // The edge of an emphasized marker (see the --fam-*-edge tokens).
+  const FAM_EDGE = {
+    "Foundation Model": "var(--fam-foundation-edge)",
+    "Tree-based": "var(--fam-tree-edge)",
+    "Neural Network": "var(--fam-nn-edge)",
+    "System": "var(--fam-system-edge)",
+    [FAM_MERGED]: "var(--fam-baseline-edge)",
   };
 
   // Create an SVG element with attributes, optionally appended to `parent`.

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_shared.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_shared.py
@@ -45,7 +45,7 @@ def _family_css_vars() -> str:
     for family, token in _FAMILY_CSS_TOKENS.items():
         color = FAMILY_COLORS[family]
         lines.append(f"    {token}: {color};")
-        lines.append(f"    {token}-edge: {marker_edge_color(color, emphasized=True)};")
+        lines.append(f"    {token}-edge: {marker_edge_color(color)};")
     return "\n".join(lines)
 
 

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -116,33 +116,33 @@ __BASE_JS__
   // Matches the point labels drawn in `render` — see the side/overlap logic there.
   const textWidth = makeTextMeasurer(svg, { size: 13, weight: 700 });
 
-  // Marker glyph per variant at (cx, cy); trajectories use circles everywhere.
-  function drawMark(parent, cx, cy, variant, color, size, opacity, dataM, whiteStroke) {
+  // Marker glyph per variant at (cx, cy); trajectories use circles everywhere. `edge`
+  // outlines the glyph; the X glyph has no fill, so its edge is a wider stroke beneath it.
+  function drawMark(parent, cx, cy, variant, color, edge, size, opacity, dataM) {
     const common = { opacity: opacity, "data-m": dataM };
+    const outline = { stroke: edge, "stroke-width": 1.2 };
     let node;
     if (TRAJECTORY || variant === "Default" || !variant) {
-      node = el("circle", { ...common, cx, cy, r: size, fill: color }, parent);
+      node = el("circle", { ...common, ...outline, cx, cy, r: size, fill: color }, parent);
     } else if (variant === "Tuned") {
       const s = size * 1.75;
-      node = el("rect", { ...common, x: cx - s / 2, y: cy - s / 2, width: s, height: s, rx: 1.5, fill: color }, parent);
+      node = el("rect", { ...common, ...outline, x: cx - s / 2, y: cy - s / 2, width: s, height: s, rx: 1.5, fill: color }, parent);
     } else if (variant === "Tuned + Ens.") {
       const d = size * 0.95;
-      node = el("path", {
+      const cross = {
         ...common,
         d: `M${cx - d},${cy - d} L${cx + d},${cy + d} M${cx - d},${cy + d} L${cx + d},${cy - d}`,
-        stroke: color, "stroke-width": size * 0.62, fill: "none", "stroke-linecap": "round",
-      }, parent);
+        fill: "none", "stroke-linecap": "round",
+      };
+      el("path", { ...cross, stroke: edge, "stroke-width": size * 0.62 + 2.4 }, parent);
+      node = el("path", { ...cross, stroke: color, "stroke-width": size * 0.62 }, parent);
     } else {
       // Any other variant (e.g. "Baseline", holdout types): diamond.
       const s = size * 1.45;
       node = el("rect", {
-        ...common, x: cx - s / 2, y: cy - s / 2, width: s, height: s, rx: 1,
+        ...common, ...outline, x: cx - s / 2, y: cy - s / 2, width: s, height: s, rx: 1,
         fill: color, transform: `rotate(45 ${cx} ${cy})`,
       }, parent);
-    }
-    if (whiteStroke && variant !== "Tuned + Ens.") {
-      node.setAttribute("stroke", "var(--card)");
-      node.setAttribute("stroke-width", "1");
     }
     return node;
   }
@@ -330,9 +330,13 @@ __BASE_JS__
       const on = isOn(method);
       for (const p of pts) {
         const color = on ? FAM_VAR[p.family] : "var(--pt-muted)";
+        // A muted marker keeps its family on the edge, its face being grey. An active
+        // marker's edge is a darker shade of its face on the light surface and the card
+        // color on the dark one (the --fam-*-edge tokens).
+        const edge = on ? FAM_EDGE[p.family] : FAM_VAR[p.family];
         const size = (on ? 7 : 5) * (TRAJECTORY ? 0.8 : 1);
         const op = on ? 0.95 : 0.5;
-        drawMark(on ? ptsOn : ptsOff, X(p[xKey]), Y(mval(p, metric)), p.variant, color, size, op, p.method, on);
+        drawMark(on ? ptsOn : ptsOff, X(p[xKey]), Y(mval(p, metric)), p.variant, color, edge, size, op, p.method);
         // Imputation ring: every affected point in scatter mode; only the
         // trajectory's end point in trajectory mode (a ring on all ~8 line
         // points would read as beads, and the chip's ‡ already flags the line).

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -117,10 +117,11 @@ __BASE_JS__
   const textWidth = makeTextMeasurer(svg, { size: 13, weight: 700 });
 
   // Marker glyph per variant at (cx, cy); trajectories use circles everywhere. `edge`
-  // outlines the glyph; the X glyph has no fill, so its edge is a wider stroke beneath it.
+  // (a color, or null for none) outlines the glyph; the X glyph has no fill, so its edge
+  // is a wider stroke beneath it.
   function drawMark(parent, cx, cy, variant, color, edge, size, opacity, dataM) {
     const common = { opacity: opacity, "data-m": dataM };
-    const outline = { stroke: edge, "stroke-width": 1.2 };
+    const outline = edge ? { stroke: edge, "stroke-width": 1.2 } : {};
     let node;
     if (TRAJECTORY || variant === "Default" || !variant) {
       node = el("circle", { ...common, ...outline, cx, cy, r: size, fill: color }, parent);
@@ -134,7 +135,7 @@ __BASE_JS__
         d: `M${cx - d},${cy - d} L${cx + d},${cy + d} M${cx - d},${cy + d} L${cx + d},${cy - d}`,
         fill: "none", "stroke-linecap": "round",
       };
-      el("path", { ...cross, stroke: edge, "stroke-width": size * 0.62 + 2.4 }, parent);
+      if (edge) el("path", { ...cross, stroke: edge, "stroke-width": size * 0.62 + 2.4 }, parent);
       node = el("path", { ...cross, stroke: color, "stroke-width": size * 0.62 }, parent);
     } else {
       // Any other variant (e.g. "Baseline", holdout types): diamond.
@@ -330,10 +331,10 @@ __BASE_JS__
       const on = isOn(method);
       for (const p of pts) {
         const color = on ? FAM_VAR[p.family] : "var(--pt-muted)";
-        // A muted marker keeps its family on the edge, its face being grey. An active
-        // marker's edge is a darker shade of its face on the light surface and the card
-        // color on the dark one (the --fam-*-edge tokens).
-        const edge = on ? FAM_EDGE[p.family] : FAM_VAR[p.family];
+        // An active marker's edge is a darker shade of its face on the light surface and
+        // the card color on the dark one (the --fam-*-edge tokens). Muted markers stay
+        // plain grey, easy to ignore.
+        const edge = on ? FAM_EDGE[p.family] : null;
         const size = (on ? 7 : 5) * (TRAJECTORY ? 0.8 : 1);
         const op = on ? 0.95 : 0.5;
         drawMark(on ? ptsOn : ptsOff, X(p[xKey]), Y(mval(p, metric)), p.variant, color, edge, size, op, p.method);

--- a/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
+++ b/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
@@ -3,9 +3,9 @@
 Design: color encodes the *model family* (few hues) instead of one hue per
 method; only Pareto-front members plus an explicit ``focus_methods`` list are
 emphasized (family color, direct label, full opacity) while every other method
-recedes into a grey field, its family kept on the marker edge. Thin connectors
-tie a method's variants (default / tuned / tuned + ensembled) together, and the
-legend collapses to a single strip above the axes.
+recedes into a grey field. Thin connectors tie a method's variants (default /
+tuned / tuned + ensembled) together, and the legend collapses to a single strip
+above the axes.
 """
 
 from __future__ import annotations
@@ -74,16 +74,13 @@ def compute_front_methods(
     return front, {n for n in names if n is not None}
 
 
-def marker_edge_color(family_color: str, *, emphasized: bool) -> str:
-    """Edge color of a marker: its family color, darkened when the marker is emphasized.
+def marker_edge_color(family_color: str) -> str:
+    """Edge color of an emphasized marker: its family color, darkened.
 
-    Muted markers are grey-filled, so the family-colored edge is what still tells their
-    family apart; emphasized markers are filled with the family color, so their edge is a
-    darker shade of it. ``family_color`` is ``#rrggbb`` (the :data:`FAMILY_COLORS` form) and
-    so is the result, which the interactive explorers emit into their CSS.
+    The face already carries the family color, so the edge is a darker shade of it rather
+    than black. ``family_color`` is ``#rrggbb`` (the :data:`FAMILY_COLORS` form) and so is
+    the result, which the interactive explorers emit into their CSS.
     """
-    if not emphasized:
-        return family_color
     channels = (int(family_color[i : i + 2], 16) for i in (1, 3, 5))
     return "#" + "".join(f"{round(c * (1 - EDGE_DARKEN)):02x}" for c in channels)
 
@@ -196,8 +193,8 @@ def plot_pareto_focus(
             zorder=2 if emph else 1,
         )
 
-    # Points. The face carries the fade; the edge stays opaque so a muted marker's family
-    # still reads off its edge.
+    # Points. An emphasized marker's edge is a darker shade of its family color; a muted
+    # marker keeps a white hairline so the grey field stays easy to ignore.
     for _, p in data.iterrows():
         method = p[method_col]
         emph = method in emphasized
@@ -207,8 +204,8 @@ def plot_pareto_focus(
             marker=variant_markers.get(p[variant_col], "o"),
             s=130 if emph else 70,
             facecolor=to_rgba(_color(method), 0.95 if emph else 0.55),
-            edgecolor=marker_edge_color(_family_color(method), emphasized=emph),
-            linewidth=1.0 if emph else 0.9,
+            edgecolor=marker_edge_color(_family_color(method)) if emph else "white",
+            linewidth=1.0 if emph else 0.4,
             zorder=4 if emph else 3,
         )
 

--- a/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
+++ b/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
@@ -74,19 +74,18 @@ def compute_front_methods(
     return front, {n for n in names if n is not None}
 
 
-def marker_edge_color(family_color: str, *, emphasized: bool) -> tuple[float, float, float]:
+def marker_edge_color(family_color: str, *, emphasized: bool) -> str:
     """Edge color of a marker: its family color, darkened when the marker is emphasized.
 
     Muted markers are grey-filled, so the family-colored edge is what still tells their
     family apart; emphasized markers are filled with the family color, so their edge is a
-    darker shade of it.
+    darker shade of it. ``family_color`` is ``#rrggbb`` (the :data:`FAMILY_COLORS` form) and
+    so is the result, which the interactive explorers emit into their CSS.
     """
-    from matplotlib.colors import to_rgb
-
-    r, g, b = to_rgb(family_color)
     if not emphasized:
-        return (r, g, b)
-    return (r * (1 - EDGE_DARKEN), g * (1 - EDGE_DARKEN), b * (1 - EDGE_DARKEN))
+        return family_color
+    channels = (int(family_color[i : i + 2], 16) for i in (1, 3, 5))
+    return "#" + "".join(f"{round(c * (1 - EDGE_DARKEN)):02x}" for c in channels)
 
 
 def plot_pareto_focus(

--- a/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
+++ b/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
@@ -3,9 +3,9 @@
 Design: color encodes the *model family* (few hues) instead of one hue per
 method; only Pareto-front members plus an explicit ``focus_methods`` list are
 emphasized (family color, direct label, full opacity) while every other method
-recedes into a grey field. Thin connectors tie a method's variants (default /
-tuned / tuned + ensembled) together, and the legend collapses to a single strip
-above the axes.
+recedes into a grey field, its family kept on the marker edge. Thin connectors
+tie a method's variants (default / tuned / tuned + ensembled) together, and the
+legend collapses to a single strip above the axes.
 """
 
 from __future__ import annotations
@@ -36,6 +36,9 @@ FAMILY_COLORS: dict[str, str] = {
 
 #: Grey used for non-emphasized ("field") methods.
 MUTED_COLOR = "#b9b8b1"
+
+#: How far an emphasized marker's edge is blended from its family color toward black.
+EDGE_DARKEN = 0.4
 
 #: Variant ("Type") -> matplotlib marker; mirrors ``LeaderboardReporter.style_markers``.
 DEFAULT_VARIANT_MARKERS: dict[str, str] = {
@@ -71,6 +74,21 @@ def compute_front_methods(
     return front, {n for n in names if n is not None}
 
 
+def marker_edge_color(family_color: str, *, emphasized: bool) -> tuple[float, float, float]:
+    """Edge color of a marker: its family color, darkened when the marker is emphasized.
+
+    Muted markers are grey-filled, so the family-colored edge is what still tells their
+    family apart; emphasized markers are filled with the family color, so their edge is a
+    darker shade of it.
+    """
+    from matplotlib.colors import to_rgb
+
+    r, g, b = to_rgb(family_color)
+    if not emphasized:
+        return (r, g, b)
+    return (r * (1 - EDGE_DARKEN), g * (1 - EDGE_DARKEN), b * (1 - EDGE_DARKEN))
+
+
 def plot_pareto_focus(
     data: pd.DataFrame,
     *,
@@ -84,6 +102,8 @@ def plot_pareto_focus(
     xlog: bool = True,
     focus_methods: list[str] | None = None,
     emphasize_all: bool = False,
+    label_halo: bool = True,
+    y_margin: float = 0.1,
     x_label: str | None = None,
     y_label: str | None = None,
     title: str | None = None,
@@ -92,7 +112,7 @@ def plot_pareto_focus(
     add_optimal_arrow: bool = True,
     variant_markers: dict[str, str] | None = None,
     ylim: tuple[float | None, float | None] | None = None,
-    figsize: tuple[float, float] = (10.5, 6.2),
+    figsize: tuple[float, float] = (10.5, 7.4),
 ):
     """Render the focus-style Pareto scatter.
 
@@ -110,11 +130,19 @@ def plot_pareto_focus(
         Emphasize (family colors + a plain label) *every* method instead of muting
         the Pareto-dominated ones. ``focus_methods`` still controls which labels
         are boxed.
+    label_halo
+        Draw the white stroke behind each label. Matplotlib writes text that carries
+        path effects as glyph outlines, so pass False to keep the labels as text in
+        an SVG.
+    y_margin
+        Autoscale margin of the y axis, as a fraction of the data range on each side:
+        room for the labels above the top points and below the bottom ones.
     max_X, max_Y
         Direction of "better" per axis (both False = lower-left is optimal).
     """
     import matplotlib.patheffects as PathEffects
     import matplotlib.pyplot as plt
+    from matplotlib.colors import to_rgba
     from matplotlib.lines import Line2D
     from matplotlib.patches import Patch
 
@@ -147,10 +175,11 @@ def plot_pareto_focus(
 
     method_family = data.groupby(method_col)[family_col].first().to_dict()
 
+    def _family_color(method: str) -> str:
+        return FAMILY_COLORS.get(method_family.get(method), FAMILY_COLORS["Other"])
+
     def _color(method: str) -> str:
-        if method in emphasized:
-            return FAMILY_COLORS.get(method_family.get(method), FAMILY_COLORS["Other"])
-        return MUTED_COLOR
+        return _family_color(method) if method in emphasized else MUTED_COLOR
 
     # Connectors linking a method's variants (default -> tuned -> tuned + ensembled).
     for method, g in data.groupby(method_col):
@@ -168,7 +197,8 @@ def plot_pareto_focus(
             zorder=2 if emph else 1,
         )
 
-    # Points.
+    # Points. The face carries the fade; the edge stays opaque so a muted marker's family
+    # still reads off its edge.
     for _, p in data.iterrows():
         method = p[method_col]
         emph = method in emphasized
@@ -177,13 +207,13 @@ def plot_pareto_focus(
             p[y_col],
             marker=variant_markers.get(p[variant_col], "o"),
             s=130 if emph else 70,
-            c=_color(method),
-            alpha=0.95 if emph else 0.55,
-            edgecolor="#0b0b0b" if emph else "white",
-            linewidth=0.8 if emph else 0.4,
+            facecolor=to_rgba(_color(method), 0.95 if emph else 0.55),
+            edgecolor=marker_edge_color(_family_color(method), emphasized=emph),
+            linewidth=1.0 if emph else 0.9,
             zorder=4 if emph else 3,
         )
 
+    ax.margins(y=y_margin)
     if ylim is not None:
         ax.set_ylim(ylim)
 
@@ -218,7 +248,7 @@ def plot_pareto_focus(
             p[y_col],
             method,
             fontsize=10.5 if is_focus else 9.5,
-            color=FAMILY_COLORS.get(method_family.get(method), FAMILY_COLORS["Other"]),
+            color=_family_color(method),
             fontweight="bold",
             ha="left",
             va="bottom",
@@ -227,7 +257,8 @@ def plot_pareto_focus(
             else None,
             zorder=6,
         )
-        txt.set_path_effects([PathEffects.withStroke(linewidth=3, foreground="white")])
+        if label_halo:
+            txt.set_path_effects([PathEffects.withStroke(linewidth=3, foreground="white")])
         texts.append(txt)
     if has_adjust_text and texts:
         adjust_text(

--- a/tests/tabarena/benchmark/experiment/test_persist_inference.py
+++ b/tests/tabarena/benchmark/experiment/test_persist_inference.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 from autogluon.core.metrics import get_metric
 from autogluon.core.models import AbstractModel
 
-from tabarena.benchmark.exec_models.autogluon import AGModelWrapper, AGWrapper
+from tabarena.benchmark.exec_models.autogluon import AGModelWrapper, AGSingleWrapper, AGWrapper
 
 
 class _PreparableModel:
@@ -34,8 +34,8 @@ class _FakePredictor:
         self._trainer = SimpleNamespace(models=trainer_models)
         self.calls: list[tuple] = []
 
-    def persist(self, models):
-        self.calls.append(("persist", models))
+    def persist(self, models, max_memory=0.4):
+        self.calls.append(("persist", models, max_memory))
         return list(self._persist_returns)
 
     def unpersist(self):
@@ -64,7 +64,7 @@ def test_pre_predict_persists_and_dispatches_prepare_for_inference():
 
     wrapper.pre_predict()
 
-    assert wrapper.predictor.calls == [("persist", "best")]
+    assert wrapper.predictor.calls == [("persist", "best", 0.4)]
     assert wrapper._persisted_models == ["bag"]
     assert prepared == ["bag", "child"]  # hook on the bag and its loaded child; others skipped
 
@@ -74,6 +74,19 @@ def test_pre_predict_records_memory_guard_skip():
     wrapper.predictor = _FakePredictor(persist_returns=[], trainer_models={})
     wrapper.pre_predict()
     assert wrapper._persisted_models == []  # persist attempted but skipped by the memory guard
+
+
+def test_pre_predict_forwards_persist_max_memory():
+    wrapper = _make_wrapper()
+    wrapper.persist_max_memory = None
+    wrapper.predictor = _FakePredictor(persist_returns=["m"], trainer_models={})
+    wrapper.pre_predict()
+    assert wrapper.predictor.calls == [("persist", "best", None)]
+
+
+def test_single_wrapper_skips_the_persist_memory_guard():
+    assert AGWrapper.persist_max_memory == 0.4
+    assert AGSingleWrapper.persist_max_memory is None
 
 
 def test_pre_predict_disabled_does_nothing():

--- a/tests/tabarena/plot/interactive/test_pareto_explorer.py
+++ b/tests/tabarena/plot/interactive/test_pareto_explorer.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from tabarena.plot.interactive.pareto_explorer import build_pareto_explorer_html
+from tabarena.plot.plot_pareto_focus import FAMILY_COLORS, marker_edge_color
 
 
 def _scatter_points() -> pd.DataFrame:
@@ -38,6 +39,10 @@ def test_build_scatter_explorer(tmp_path):
     assert "Pareto front" in html
     # Family colors injected from the shared leaderboard scheme.
     assert "--fam-foundation: #b07cf0;" in html
+    # Marker edges: the family color darkened for the light surface, as in the static figures.
+    edge = marker_edge_color(FAMILY_COLORS["Foundation Model"], emphasized=True)
+    assert f"--fam-foundation-edge: {edge};" in html
+    assert "const edge = on ? FAM_EDGE[p.family] : FAM_VAR[p.family];" in html
 
 
 def test_x_keys_selects_and_orders_axes(tmp_path):

--- a/tests/tabarena/plot/interactive/test_pareto_explorer.py
+++ b/tests/tabarena/plot/interactive/test_pareto_explorer.py
@@ -40,9 +40,9 @@ def test_build_scatter_explorer(tmp_path):
     # Family colors injected from the shared leaderboard scheme.
     assert "--fam-foundation: #b07cf0;" in html
     # Marker edges: the family color darkened for the light surface, as in the static figures.
-    edge = marker_edge_color(FAMILY_COLORS["Foundation Model"], emphasized=True)
+    edge = marker_edge_color(FAMILY_COLORS["Foundation Model"])
     assert f"--fam-foundation-edge: {edge};" in html
-    assert "const edge = on ? FAM_EDGE[p.family] : FAM_VAR[p.family];" in html
+    assert "const edge = on ? FAM_EDGE[p.family] : null;" in html
 
 
 def test_x_keys_selects_and_orders_axes(tmp_path):

--- a/tests/tabarena/plot/test_plot_pareto_focus.py
+++ b/tests/tabarena/plot/test_plot_pareto_focus.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import matplotlib
 import pandas as pd
+import pytest
+from matplotlib.colors import to_rgb
 
 matplotlib.use("Agg", force=True)
 
-from tabarena.plot.plot_pareto_focus import compute_front_methods, plot_pareto_focus
+from tabarena.plot.plot_pareto_focus import compute_front_methods, marker_edge_color, plot_pareto_focus
 
 
 def _toy_points() -> pd.DataFrame:
@@ -53,3 +55,27 @@ def test_plot_pareto_focus_writes_figure(tmp_path):
     )
     assert save_path.is_file()
     assert save_path.stat().st_size > 0
+
+
+def test_marker_edge_color_darkens_emphasized_markers_only():
+    family = "#5cb85c"
+    muted_edge = marker_edge_color(family, emphasized=False)
+    emphasized_edge = marker_edge_color(family, emphasized=True)
+    assert muted_edge == pytest.approx(to_rgb(family))
+    assert all(e < m for e, m in zip(emphasized_edge, muted_edge, strict=True))
+
+
+def test_label_halo_off_keeps_svg_labels_as_text(tmp_path):
+    """A haloed label is written as glyph outlines; without the halo it stays a text node."""
+    with matplotlib.rc_context({"svg.fonttype": "none"}):
+        for halo in (True, False):
+            plot_pareto_focus(
+                data=_toy_points(),
+                x_col="x",
+                y_col="y",
+                focus_methods=["C"],
+                label_halo=halo,
+                save_path=tmp_path / f"halo_{halo}.svg",
+            )
+    assert ">C<" not in (tmp_path / "halo_True.svg").read_text()
+    assert ">C<" in (tmp_path / "halo_False.svg").read_text()

--- a/tests/tabarena/plot/test_plot_pareto_focus.py
+++ b/tests/tabarena/plot/test_plot_pareto_focus.py
@@ -56,11 +56,10 @@ def test_plot_pareto_focus_writes_figure(tmp_path):
     assert save_path.stat().st_size > 0
 
 
-def test_marker_edge_color_darkens_emphasized_markers_only():
+def test_marker_edge_color_darkens_the_family_color():
     family = "#5cb85c"
-    assert marker_edge_color(family, emphasized=False) == family
-    emphasized_edge = to_rgb(marker_edge_color(family, emphasized=True))
-    assert all(e < f for e, f in zip(emphasized_edge, to_rgb(family), strict=True))
+    edge = to_rgb(marker_edge_color(family))
+    assert all(e < f for e, f in zip(edge, to_rgb(family), strict=True))
 
 
 def test_label_halo_off_keeps_svg_labels_as_text(tmp_path):

--- a/tests/tabarena/plot/test_plot_pareto_focus.py
+++ b/tests/tabarena/plot/test_plot_pareto_focus.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import matplotlib
 import pandas as pd
-import pytest
 from matplotlib.colors import to_rgb
 
 matplotlib.use("Agg", force=True)
@@ -59,10 +58,9 @@ def test_plot_pareto_focus_writes_figure(tmp_path):
 
 def test_marker_edge_color_darkens_emphasized_markers_only():
     family = "#5cb85c"
-    muted_edge = marker_edge_color(family, emphasized=False)
-    emphasized_edge = marker_edge_color(family, emphasized=True)
-    assert muted_edge == pytest.approx(to_rgb(family))
-    assert all(e < m for e, m in zip(emphasized_edge, muted_edge, strict=True))
+    assert marker_edge_color(family, emphasized=False) == family
+    emphasized_edge = to_rgb(marker_edge_color(family, emphasized=True))
+    assert all(e < f for e, f in zip(emphasized_edge, to_rgb(family), strict=True))
 
 
 def test_label_halo_off_keeps_svg_labels_as_text(tmp_path):


### PR DESCRIPTION
Changes to the focus Pareto figures, static and interactive, plus a fix for the two tests failing on main since #514.

## Changes

- Static figure (`plot_pareto_focus`): emphasized markers get an edge in a darker shade of their family color (`EDGE_DARKEN = 0.4`) instead of black. Muted markers stay plain grey with their white hairline, so the field remains easy to ignore.
- Static figure: more vertical room. `y_margin=0.1` (matplotlib's default autoscale margin is 0.05) and a taller default figure (10.5 x 7.4 in, was 6.2), so the boxed focus labels no longer sit on the top edge.
- Static figure: new `label_halo` parameter, default unchanged. Matplotlib writes text that carries path effects as glyph outlines even under `svg.fonttype = "none"`, so `label_halo=False` is what keeps SVG labels as editable text.
- Interactive explorers (Pareto and tuning trajectories): active markers were stroked with the card color, which is white and invisible on the light surface. They now get the family color darkened on the light surface (new `--fam-*-edge` tokens, generated from `FAMILY_COLORS` with the same `marker_edge_color` as the static figure) and keep the card color on the dark surface. The X glyph gets its edge as a wider stroke beneath it. Muted markers stay unstroked grey.
- `test_persist_inference.py`: since #514, `pre_predict` passes `max_memory=self.persist_max_memory`, and the fake predictor only accepted `models`, so the call raised inside the guarded block and two tests failed. The fake now records the keyword, and two new tests pin the forwarded value (0.4 on `AGWrapper`, `None` on `AGSingleWrapper`).

## Why

We use these figures as picking sheets for report baselines. The top labels collided with the axis edge, the emphasized markers' black edges read heavier than the family colors, and in the explorer's light mode the edge was invisible. The SVG export of the same figures needs text labels so they can be moved in a vector editor.

## Tests

`pytest tests/tabarena/plot tests/tabarena/benchmark/experiment/test_persist_inference.py` passes (60 tests) and so does the default suite. New tests: `marker_edge_color` darkens the family color, `label_halo=False` keeps the `<text>` node in an SVG, and the explorer page carries the edge tokens and the edge choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
