### PR TITLE
Forward figure options through plot_pareto and size the muted markers

### DIFF
--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -177,7 +177,7 @@ class LeaderboardReporter:
             "Default",
             "Tuned",
             "Tuned + Ens.",
-            "Baseline",
+            "End-to-end",
             "Best",
             "Default, Holdout",
             "Tuned, Holdout",
@@ -188,7 +188,7 @@ class LeaderboardReporter:
             "Default": "o",
             "Tuned": "s",
             "Tuned + Ens.": "X",
-            "Baseline": "D",
+            "End-to-end": "D",
             "Best": "*",
             "Default, Holdout": "^",
             "Tuned, Holdout": "<",
@@ -2071,7 +2071,9 @@ class LeaderboardReporter:
 
         leaderboard_pareto[self.method_col] = leaderboard_pareto["Method"] + leaderboard_pareto["suffix"]
         fig_rename_dict = {
-            "baseline": "Baseline",
+            # A method without a tuning variant ran end to end inside its own budget, the
+            # leaderboard table's word for a system.
+            "baseline": "End-to-end",
             "default": "Default",
             "tuned": "Tuned",
             "tuned_ensembled": "Tuned + Ens.",
@@ -2089,7 +2091,7 @@ class LeaderboardReporter:
         )
 
         if not with_baselines:
-            leaderboard_pareto = leaderboard_pareto[leaderboard_pareto["Type"] != "Baseline"]
+            leaderboard_pareto = leaderboard_pareto[leaderboard_pareto["Type"] != "End-to-end"]
 
         self.plot_pareto_elo_vs_time_infer(leaderboard=leaderboard_pareto, **plot_pareto_kwargs)
         self.plot_pareto_elo_vs_time_train(leaderboard=leaderboard_pareto, **plot_pareto_kwargs)

--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -822,6 +822,7 @@ class LeaderboardReporter:
         method_color_overrides: dict[str, str] | None = None,
         pareto_emphasize_all: bool = False,
         pareto_focus_kwargs: dict | None = None,
+        pareto_explorer_kwargs: dict | None = None,
         website_only: bool = False,
     ) -> pd.DataFrame:
         """Compute the leaderboard for ``df_results`` and render the TabArena figures.
@@ -875,6 +876,10 @@ class LeaderboardReporter:
         ``pareto_focus_kwargs`` (default ``None``) is forwarded to :func:`plot_pareto_focus` for the
         four Pareto figures, e.g. ``{"muted_size": 45, "muted_alpha": 0.4}`` to shrink and fade the
         methods off the front, or ``{"label_halo": False}`` for an SVG with text labels.
+
+        ``pareto_explorer_kwargs`` (default ``None``) is forwarded to :func:`build_pareto_explorer_html`
+        for the two explorer pages, e.g. ``{"dim_off_front": True}`` to shrink and fade the selected
+        points that are not on the front.
 
         ``method_color_overrides`` (default ``None``) pins a fixed color per method in both the Elo
         bar plot (recolors that method's bar) and the Pareto plots (colors its points) — a
@@ -1422,6 +1427,7 @@ class LeaderboardReporter:
                 method_color_overrides=method_color_overrides,
                 pareto_emphasize_all=pareto_emphasize_all,
                 pareto_focus_kwargs=pareto_focus_kwargs,
+                pareto_explorer_kwargs=pareto_explorer_kwargs,
             )
 
         return leaderboard
@@ -2010,6 +2016,7 @@ class LeaderboardReporter:
         method_color_overrides: dict[str, str] | None = None,
         pareto_emphasize_all: bool = False,
         pareto_focus_kwargs: dict | None = None,
+        pareto_explorer_kwargs: dict | None = None,
     ):
         _f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
             framework_types=framework_types,
@@ -2097,7 +2104,7 @@ class LeaderboardReporter:
         self.plot_pareto_elo_vs_time_train(leaderboard=leaderboard_pareto, **plot_pareto_kwargs)
         self.plot_pareto_improvability_vs_time_infer(leaderboard=leaderboard_pareto, **plot_pareto_kwargs)
         self.plot_pareto_improvability_vs_time_train(leaderboard=leaderboard_pareto, **plot_pareto_kwargs)
-        self.build_pareto_explorer(leaderboard=leaderboard_pareto)
+        self.build_pareto_explorer(leaderboard=leaderboard_pareto, **(pareto_explorer_kwargs or {}))
 
     def _plot_pareto_focus_figure(
         self,
@@ -2232,11 +2239,13 @@ class LeaderboardReporter:
             **focus_kwargs,
         )
 
-    def build_pareto_explorer(self, leaderboard: pd.DataFrame):
+    def build_pareto_explorer(self, leaderboard: pd.DataFrame, **explorer_kwargs):
         """Write the self-contained interactive Pareto explorers — one per time axis:
         ``pareto_front_explorer.html`` (inference time) and
         ``pareto_front_explorer_time_train.html`` (train time) — and their underlying
         data (``pareto_front_points.csv``) next to the static figures.
+
+        ``explorer_kwargs`` go to :func:`build_pareto_explorer_html`, e.g. ``dim_off_front=True``.
         """
         points = pd.DataFrame(
             {
@@ -2270,6 +2279,7 @@ class LeaderboardReporter:
             # Mirrored against the trajectories explorer (chips right there).
             chips_side="left",
             save_path=Path(self.output_dir) / "pareto_front_explorer.html",
+            **explorer_kwargs,
         )
         build_pareto_explorer_html(
             points=points,
@@ -2277,6 +2287,7 @@ class LeaderboardReporter:
             chips_side="left",
             save_path=Path(self.output_dir) / "pareto_front_explorer_time_train.html",
             page_title="TabArena Pareto explorer — train time",
+            **explorer_kwargs,
         )
 
     def get_method_rename_map(self) -> dict[str, str]:

--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -821,6 +821,7 @@ class LeaderboardReporter:
         plot_only: list[str] | None = None,
         method_color_overrides: dict[str, str] | None = None,
         pareto_emphasize_all: bool = False,
+        pareto_focus_kwargs: dict | None = None,
         website_only: bool = False,
     ) -> pd.DataFrame:
         """Compute the leaderboard for ``df_results`` and render the TabArena figures.
@@ -870,6 +871,10 @@ class LeaderboardReporter:
         ``"TabPFN-3"``); see :meth:`_plot_only_to_hidden_methods`. Implemented as
         the complement of the existing ``hidden_methods`` denylist (carried in
         ``plot_tuning_kwargs``), so the two compose — anything hidden stays hidden.
+
+        ``pareto_focus_kwargs`` (default ``None``) is forwarded to :func:`plot_pareto_focus` for the
+        four Pareto figures, e.g. ``{"muted_size": 45, "muted_alpha": 0.4}`` to shrink and fade the
+        methods off the front, or ``{"label_halo": False}`` for an SVG with text labels.
 
         ``method_color_overrides`` (default ``None``) pins a fixed color per method in both the Elo
         bar plot (recolors that method's bar) and the Pareto plots (colors its points) — a
@@ -1416,6 +1421,7 @@ class LeaderboardReporter:
                 plot_tuning_kwargs=plot_tuning_kwargs,
                 method_color_overrides=method_color_overrides,
                 pareto_emphasize_all=pareto_emphasize_all,
+                pareto_focus_kwargs=pareto_focus_kwargs,
             )
 
         return leaderboard
@@ -2003,6 +2009,7 @@ class LeaderboardReporter:
         plot_tuning_kwargs: dict | None = None,
         method_color_overrides: dict[str, str] | None = None,
         pareto_emphasize_all: bool = False,
+        pareto_focus_kwargs: dict | None = None,
     ):
         _f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
             framework_types=framework_types,
@@ -2026,6 +2033,9 @@ class LeaderboardReporter:
             # Show the Pareto-dominated methods with full family colors and labels
             # instead of muting them (see `plot_pareto_focus`'s `emphasize_all`).
             plot_pareto_kwargs["emphasize_all"] = True
+        if pareto_focus_kwargs:
+            # Anything `plot_pareto_focus` accepts, e.g. the muted markers' size and opacity.
+            plot_pareto_kwargs.update(pareto_focus_kwargs)
         if plot_tuning_kwargs is not None:
             if "hidden_methods" in plot_tuning_kwargs:
                 leaderboard_pareto = leaderboard_pareto[
@@ -2101,6 +2111,7 @@ class LeaderboardReporter:
         title: str | None = None,
         focus_methods: list[str] | None = None,
         emphasize_all: bool = False,
+        **focus_kwargs,
     ):
         """Shared body of the four ``pareto_front_*`` website figures: map the
         leaderboard's raw columns onto display axes and render the focus-style
@@ -2126,6 +2137,7 @@ class LeaderboardReporter:
             title=title,
             save_path=str(Path(self.output_dir) / f"{file_name}.{self.figure_file_type}"),
             show=False,
+            **focus_kwargs,
         )
 
     def plot_pareto_elo_vs_time_train(
@@ -2134,6 +2146,7 @@ class LeaderboardReporter:
         title: str | None = "auto",
         focus_methods: list[str] | None = None,
         emphasize_all: bool = False,
+        **focus_kwargs,
     ):
         self._plot_pareto_focus_figure(
             leaderboard,
@@ -2146,6 +2159,7 @@ class LeaderboardReporter:
             title=f"{self.benchmark_name}: Elo vs Train Time" if title == "auto" else title,
             focus_methods=focus_methods,
             emphasize_all=emphasize_all,
+            **focus_kwargs,
         )
 
     def plot_pareto_elo_vs_time_infer(
@@ -2154,6 +2168,7 @@ class LeaderboardReporter:
         title: str | None = "auto",
         focus_methods: list[str] | None = None,
         emphasize_all: bool = False,
+        **focus_kwargs,
     ):
         self._plot_pareto_focus_figure(
             leaderboard,
@@ -2166,6 +2181,7 @@ class LeaderboardReporter:
             title=f"{self.benchmark_name}: Elo vs Inference Time" if title == "auto" else title,
             focus_methods=focus_methods,
             emphasize_all=emphasize_all,
+            **focus_kwargs,
         )
 
     def plot_pareto_improvability_vs_time_infer(
@@ -2174,6 +2190,7 @@ class LeaderboardReporter:
         title: str | None = "auto",
         focus_methods: list[str] | None = None,
         emphasize_all: bool = False,
+        **focus_kwargs,
     ):
         self._plot_pareto_focus_figure(
             leaderboard,
@@ -2187,6 +2204,7 @@ class LeaderboardReporter:
             title=f"{self.benchmark_name}: Improvability vs Inference Time" if title == "auto" else title,
             focus_methods=focus_methods,
             emphasize_all=emphasize_all,
+            **focus_kwargs,
         )
 
     def plot_pareto_improvability_vs_time_train(
@@ -2195,6 +2213,7 @@ class LeaderboardReporter:
         title: str | None = "auto",
         focus_methods: list[str] | None = None,
         emphasize_all: bool = False,
+        **focus_kwargs,
     ):
         self._plot_pareto_focus_figure(
             leaderboard,
@@ -2208,6 +2227,7 @@ class LeaderboardReporter:
             title=f"{self.benchmark_name}: Improvability vs Train Time" if title == "auto" else title,
             focus_methods=focus_methods,
             emphasize_all=emphasize_all,
+            **focus_kwargs,
         )
 
     def build_pareto_explorer(self, leaderboard: pd.DataFrame):

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -138,7 +138,7 @@ __BASE_JS__
       if (edge) el("path", { ...cross, stroke: edge, "stroke-width": size * 0.62 + 2.4 }, parent);
       node = el("path", { ...cross, stroke: color, "stroke-width": size * 0.62 }, parent);
     } else {
-      // Any other variant (e.g. "Baseline", holdout types): diamond.
+      // Any other variant (e.g. "End-to-end", holdout types): diamond.
       const s = size * 1.45;
       node = el("rect", {
         ...common, ...outline, x: cx - s / 2, y: cy - s / 2, width: s, height: s, rx: 1,
@@ -564,6 +564,10 @@ __BASE_JS__
         '<span class="item"><svg width="14" height="14" viewBox="0 0 14 14"><circle cx="7" cy="7" r="5" fill="var(--muted)"/></svg> Default</span>' +
         '<span class="item"><svg width="14" height="14" viewBox="0 0 14 14"><rect x="2" y="2" width="10" height="10" rx="1.5" fill="var(--muted)"/></svg> Tuned</span>' +
         '<span class="item"><svg width="14" height="14" viewBox="0 0 14 14"><path d="M3,3 L11,11 M3,11 L11,3" stroke="var(--muted)" stroke-width="2.6" stroke-linecap="round"/></svg> Tuned + Ensembled</span>';
+      // Systems draw as diamonds; the legend names them as the leaderboard table does.
+      if (POINTS.some(p => p.variant === "End-to-end")) {
+        html += '<span class="item" title="A system picked, tuned and combined its own models inside one budget; the tuning regimes do not apply to it"><svg width="14" height="14" viewBox="0 0 14 14"><rect x="3" y="3" width="8" height="8" rx="1" fill="var(--muted)" transform="rotate(45 7 7)"/></svg> End-to-end</span>';
+      }
     } else {
       html += '<span class="item"><svg width="26" height="8" viewBox="0 0 26 8"><line x1="0" y1="4" x2="26" y2="4" stroke="var(--muted)" stroke-width="2"/><circle cx="6" cy="4" r="2.6" fill="var(--muted)"/><circle cx="16" cy="4" r="2.6" fill="var(--muted)"/></svg> Tuning trajectory (more configs &rarr; more time)</span>';
     }

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -212,6 +212,7 @@ __BASE_JS__
       a[xk] - b[xk] || (metric.lowerBetter ? mval(a, metric) - mval(b, metric) : mval(b, metric) - mval(a, metric)));
     const verts = [];
     const methods = new Set();
+    const points = new Set();
     let best = null;
     for (const p of pts) {
       const v = mval(p, metric);
@@ -220,9 +221,10 @@ __BASE_JS__
         verts.push([p[xk], v]);
         best = v;
         methods.add(p.method);
+        points.add(p);
       }
     }
-    return { verts, methods };
+    return { verts, methods, points };
   }
 
   // The chart opens on the front, and keeps following it while the metric changes:
@@ -335,8 +337,11 @@ __BASE_JS__
         // the card color on the dark one (the --fam-*-edge tokens). Muted markers stay
         // plain grey, easy to ignore.
         const edge = on ? FAM_EDGE[p.family] : null;
-        const size = (on ? 7 : 5) * (TRAJECTORY ? 0.8 : 1);
-        const op = on ? 0.95 : 0.5;
+        // With `dimOffFront`, an active point that is not a vertex of the front is drawn
+        // smaller and fainter, so the front members carry the eye.
+        const dim = CONFIG.dimOffFront && on && !front.points.has(p);
+        const size = (on ? (dim ? 5.5 : 7) : 5) * (TRAJECTORY ? 0.8 : 1);
+        const op = on ? (dim ? 0.7 : 0.95) : 0.5;
         drawMark(on ? ptsOn : ptsOff, X(p[xKey]), Y(mval(p, metric)), p.variant, color, edge, size, op, p.method);
         // Imputation ring: every affected point in scatter mode; only the
         // trajectory's end point in trajectory mode (a ring on all ~8 line

--- a/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 #: Variant display order used to sort each method's points so the connector
 #: line runs default -> tuned -> tuned + ensembled.
-_VARIANT_ORDER = ["Default", "Tuned", "Tuned + Ens.", "Baseline", "Best"]
+_VARIANT_ORDER = ["Default", "Tuned", "Tuned + Ens.", "End-to-end", "Best"]
 
 #: Metric definitions the explorer's y-axis selector can offer, keyed by the
 #: column name expected in ``points``.

--- a/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
@@ -72,6 +72,7 @@ def build_pareto_explorer_html(
     metric_keys: list[str] | None = None,
     x_keys: list[str] | None = None,
     chips_side: str = "left",
+    dim_off_front: bool = False,
     page_title: str = "TabArena Pareto explorer",
 ) -> Path:
     """Render the interactive explorer HTML for a set of method points.
@@ -100,6 +101,9 @@ def build_pareto_explorer_html(
     chips_side
         ``"left"`` places the controls + method chips left of the chart,
         ``"right"`` mirrors the columns.
+    dim_off_front
+        Draw the active points that are not vertices of the current Pareto front
+        smaller and fainter, so the front members stand out among a large selection.
     """
     if chips_side not in ("left", "right"):
         raise ValueError(f"Unknown chips_side: {chips_side!r}")
@@ -156,6 +160,7 @@ def build_pareto_explorer_html(
         "metrics": [_METRIC_SPECS[k] for k in metric_keys],
         "xAxes": [_X_AXIS_SPECS[k] for k in x_keys],
         "chipsSide": chips_side,
+        "dimOffFront": dim_off_front,
     }
 
     html = render_explorer_html(EXPLORER_TEMPLATE, page_title=page_title, config=config, points=data)

--- a/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
+++ b/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
@@ -100,6 +100,8 @@ def plot_pareto_focus(
     emphasize_all: bool = False,
     label_halo: bool = True,
     y_margin: float = 0.1,
+    muted_size: float = 70,
+    muted_alpha: float = 0.55,
     x_label: str | None = None,
     y_label: str | None = None,
     title: str | None = None,
@@ -133,6 +135,10 @@ def plot_pareto_focus(
     y_margin
         Autoscale margin of the y axis, as a fraction of the data range on each side:
         room for the labels above the top points and below the bottom ones.
+    muted_size, muted_alpha
+        Marker area and opacity of the muted (Pareto-dominated, unfocused) methods.
+        Emphasized markers are drawn at 130 and 0.95; smaller and fainter values push
+        the field further into the background.
     max_X, max_Y
         Direction of "better" per axis (both False = lower-left is optimal).
     """
@@ -202,8 +208,8 @@ def plot_pareto_focus(
             p[x_col],
             p[y_col],
             marker=variant_markers.get(p[variant_col], "o"),
-            s=130 if emph else 70,
-            facecolor=to_rgba(_color(method), 0.95 if emph else 0.55),
+            s=130 if emph else muted_size,
+            facecolor=to_rgba(_color(method), 0.95 if emph else muted_alpha),
             edgecolor=marker_edge_color(_family_color(method)) if emph else "white",
             linewidth=1.0 if emph else 0.4,
             zorder=4 if emph else 3,

--- a/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
+++ b/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
@@ -45,7 +45,7 @@ DEFAULT_VARIANT_MARKERS: dict[str, str] = {
     "Default": "o",
     "Tuned": "s",
     "Tuned + Ens.": "X",
-    "Baseline": "D",
+    "End-to-end": "D",
     "Best": "*",
     "Default, Holdout": "^",
     "Tuned, Holdout": "<",

--- a/tests/tabarena/evaluation/test_leaderboard_reporter.py
+++ b/tests/tabarena/evaluation/test_leaderboard_reporter.py
@@ -207,5 +207,8 @@ class TestParetoFocusKwargs:
 
         assert len(calls) == 4
         assert all(kwargs["muted_size"] == 12 and kwargs["muted_alpha"] == 0.2 for kwargs in calls)
+        # A method without a tuning variant is typed as the leaderboard table names systems.
+        data = calls[0]["data"]
+        assert set(data.loc[data["Method"] == "TabPFN-3", "Type"]) == {"End-to-end"}
         # The plain figure options still arrive alongside.
         assert all(kwargs["variant_markers"] is reporter.style_markers for kwargs in calls)

--- a/tests/tabarena/evaluation/test_leaderboard_reporter.py
+++ b/tests/tabarena/evaluation/test_leaderboard_reporter.py
@@ -212,3 +212,25 @@ class TestParetoFocusKwargs:
         assert set(data.loc[data["Method"] == "TabPFN-3", "Type"]) == {"End-to-end"}
         # The plain figure options still arrive alongside.
         assert all(kwargs["variant_markers"] is reporter.style_markers for kwargs in calls)
+
+    def test_explorer_kwargs_reach_both_explorer_pages(self, monkeypatch, tmp_path):
+        calls: list[dict] = []
+        monkeypatch.setattr(module, "plot_pareto_focus", lambda **kwargs: None)
+        monkeypatch.setattr(module, "build_pareto_explorer_html", lambda **kwargs: calls.append(kwargs))
+        monkeypatch.setattr(module, "_init_global_rcparams", lambda: None)
+        reporter = LeaderboardReporter(output_dir=tmp_path, task_metadata=[])
+        leaderboard = pd.DataFrame(
+            {
+                "method": ["GBM (default)", "TabPFN-3"],
+                "config_type": ["GBM", None],
+                "elo": [1000.0, 1300.0],
+                "improvability": [0.2, 0.05],
+                "median_time_train_s_per_1K": [1.0, 5.0],
+                "median_time_infer_s_per_1K": [0.1, 0.5],
+            }
+        )
+
+        reporter.plot_pareto(leaderboard, framework_types=["GBM"], pareto_explorer_kwargs={"dim_off_front": True})
+
+        assert [kwargs["x_keys"] for kwargs in calls] == [["x_infer"], ["x_train"]]
+        assert all(kwargs["dim_off_front"] is True for kwargs in calls)

--- a/tests/tabarena/evaluation/test_leaderboard_reporter.py
+++ b/tests/tabarena/evaluation/test_leaderboard_reporter.py
@@ -9,6 +9,9 @@ touched — only the figures are filtered.
 
 from __future__ import annotations
 
+import pandas as pd
+
+from tabarena.evaluation import leaderboard_reporter as module
 from tabarena.evaluation.leaderboard_reporter import LeaderboardReporter
 
 # ``f_map_type_name`` maps a config method's *short* config_type to its long
@@ -177,3 +180,32 @@ class TestComputeOnlyReporter:
         import inspect
 
         assert inspect.signature(LeaderboardReporter.eval).parameters["plot"].default is True
+
+
+class TestParetoFocusKwargs:
+    def test_kwargs_reach_every_pareto_figure(self, monkeypatch, tmp_path):
+        """``pareto_focus_kwargs`` is forwarded unchanged to each of the four figure calls."""
+        calls: list[dict] = []
+        monkeypatch.setattr(module, "plot_pareto_focus", lambda **kwargs: calls.append(kwargs))
+        monkeypatch.setattr(module, "_init_global_rcparams", lambda: None)
+        monkeypatch.setattr(LeaderboardReporter, "build_pareto_explorer", lambda self, leaderboard: None)
+        reporter = LeaderboardReporter(output_dir=tmp_path, task_metadata=[])
+        leaderboard = pd.DataFrame(
+            {
+                "method": ["GBM (default)", "GBM (tuned + ensemble)", "TabPFN-3"],
+                "config_type": ["GBM", "GBM", None],
+                "elo": [1000.0, 1100.0, 1300.0],
+                "improvability": [0.2, 0.1, 0.05],
+                "median_time_train_s_per_1K": [1.0, 100.0, 5.0],
+                "median_time_infer_s_per_1K": [0.1, 1.0, 0.5],
+            }
+        )
+
+        reporter.plot_pareto(
+            leaderboard, framework_types=["GBM"], pareto_focus_kwargs={"muted_size": 12, "muted_alpha": 0.2}
+        )
+
+        assert len(calls) == 4
+        assert all(kwargs["muted_size"] == 12 and kwargs["muted_alpha"] == 0.2 for kwargs in calls)
+        # The plain figure options still arrive alongside.
+        assert all(kwargs["variant_markers"] is reporter.style_markers for kwargs in calls)

--- a/tests/tabarena/plot/interactive/test_pareto_explorer.py
+++ b/tests/tabarena/plot/interactive/test_pareto_explorer.py
@@ -132,3 +132,13 @@ def test_the_highlighted_front_follows_the_metric(tmp_path):
 def test_unknown_mode_raises(tmp_path):
     with pytest.raises(ValueError, match="mode"):
         build_pareto_explorer_html(points=_scatter_points(), save_path=tmp_path / "e.html", mode="bars")
+
+
+def test_end_to_end_marker_joins_the_legend_when_a_system_is_plotted(tmp_path):
+    points = _scatter_points()
+    points.loc[points.index[-1], "variant"] = "End-to-end"
+    out = tmp_path / "explorer.html"
+    build_pareto_explorer_html(points, save_path=out)
+    html = out.read_text()
+    assert 'if (POINTS.some(p => p.variant === "End-to-end"))' in html
+    assert "End-to-end</span>" in html

--- a/tests/tabarena/plot/interactive/test_pareto_explorer.py
+++ b/tests/tabarena/plot/interactive/test_pareto_explorer.py
@@ -142,3 +142,12 @@ def test_end_to_end_marker_joins_the_legend_when_a_system_is_plotted(tmp_path):
     html = out.read_text()
     assert 'if (POINTS.some(p => p.variant === "End-to-end"))' in html
     assert "End-to-end</span>" in html
+
+
+def test_dim_off_front_is_off_by_default_and_reaches_the_page(tmp_path):
+    points = _scatter_points()
+    default = build_pareto_explorer_html(points, save_path=tmp_path / "default.html").read_text()
+    dimmed = build_pareto_explorer_html(points, save_path=tmp_path / "dim.html", dim_off_front=True).read_text()
+    assert '"dimOffFront": false' in default
+    assert '"dimOffFront": true' in dimmed
+    assert "const dim = CONFIG.dimOffFront && on && !front.points.has(p);" in dimmed

--- a/tests/tabarena/plot/test_plot_pareto_focus.py
+++ b/tests/tabarena/plot/test_plot_pareto_focus.py
@@ -50,6 +50,8 @@ def test_plot_pareto_focus_writes_figure(tmp_path):
         x_label="Time (s)",
         y_label="Improvability (%)",
         title="Toy",
+        muted_size=40,
+        muted_alpha=0.3,
         save_path=save_path,
     )
     assert save_path.is_file()


### PR DESCRIPTION
Knobs for the focus Pareto figures and the explorer, and the leaderboard's name for systems in them, following up on #517.

## Changes

- `plot_pareto_focus` gains `muted_size` and `muted_alpha` (defaults unchanged at 70 and 0.55), so the methods off the front can be pushed further into the background.
- `build_pareto_explorer_html` gains `dim_off_front` (default off): an active point that is not a vertex of the current Pareto front is drawn smaller and fainter, so the front members carry the eye when many methods are selected.
- `LeaderboardReporter.eval` and `plot_pareto` take `pareto_focus_kwargs` and `pareto_explorer_kwargs`, forwarded unchanged to `plot_pareto_focus` (four website figures) and `build_pareto_explorer_html` (both explorer pages). Anything those functions accept can be set per run (e.g. `{"muted_size": 45, "muted_alpha": 0.4, "label_halo": False}`, `{"dim_off_front": True}`) without a new parameter at every level of the call chain.
- The static figure typed every method without a tuning variant as "Baseline" while the leaderboard table calls the same methods End-to-end. The variant is now "End-to-end" in the reporter (`fig_rename_dict`, `style_markers`, `style_order`, the `with_baselines` filter), in `DEFAULT_VARIANT_MARKERS` and in the explorer's variant order, so the figure legend and `pareto_front_points.csv` agree with the table. The diamond glyph is unchanged.
- The explorer drew systems as diamonds without a legend entry for the glyph. The legend strip now lists the diamond as End-to-end whenever such a point exists, with the same tooltip wording as the leaderboard explorer.

## Why

We render these figures as picking sheets for report baselines from our own driver via `plot_pareto`. Shrinking and fading the field or the off-front selection, and keeping SVG labels as text, should not need edits to the library or a new argument threaded through six methods each time. The legend said "Baseline" for AutoGluon and TabFM+ where the table beside it says End-to-end, and the explorer used a marker it never explained.

## Tests

`pytest tests/tabarena/plot tests/tabarena/evaluation/test_leaderboard_reporter.py` passes (65 tests). New: the muted options in the figure smoke test, `pareto_focus_kwargs` reaching all four figure calls with the system row typed End-to-end, `pareto_explorer_kwargs` reaching both explorer pages, `dim_off_front` reaching the page config, and the explorer legend entry appearing when a system is plotted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
