### PR TITLE
Draw systems as bars by default in the tuning-impact plot

### DIFF
--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -2517,7 +2517,7 @@ class LeaderboardReporter:
         save_prefix: str,
         baselines: list[str] | None = None,
         baseline_colors: list[str] | None = None,
-        baselines_as_bars: bool = False,
+        baselines_as_bars: bool = True,
         show: bool = False,
         use_gmean=False,
         use_score: bool = True,
@@ -2597,9 +2597,10 @@ class LeaderboardReporter:
                 "A color must be specified for each baseline via the `baseline_colors` argument."
             )
 
-        # `baselines_as_bars` renders every baseline as its own bar (sorted with the
-        # config-family bars) instead of a dashed reference line, via a single
-        # promote-from-baselines override shared by all of them.
+        # `baselines_as_bars` (the default) renders every baseline as its own bar, sorted
+        # with the config-family bars, via a single promote-from-baselines override shared
+        # by all of them. Pass `baselines_as_bars=False` to draw them as dashed reference
+        # lines instead.
         if baselines_as_bars and baselines:
             pastel = sns.color_palette("pastel").as_hex()
             deep = sns.color_palette("deep").as_hex()

--- a/tests/tabarena/evaluation/test_leaderboard_reporter.py
+++ b/tests/tabarena/evaluation/test_leaderboard_reporter.py
@@ -234,3 +234,55 @@ class TestParetoFocusKwargs:
 
         assert [kwargs["x_keys"] for kwargs in calls] == [["x_infer"], ["x_train"]]
         assert all(kwargs["dim_off_front"] is True for kwargs in calls)
+
+
+class TestBaselinesAsBars:
+    """Systems (``baselines``) in ``plot_tuning_impact`` are bars by default, not dashed lines."""
+
+    @staticmethod
+    def _render(monkeypatch, tmp_path, **kwargs) -> tuple[list[str], int]:
+        """Return the legend labels at save time and how many reference lines were drawn."""
+        import matplotlib.pyplot as plt
+        from matplotlib.axes import Axes
+
+        legend_labels: list[str] = []
+        lines: list[float] = []
+        monkeypatch.setattr(module, "_init_global_rcparams", lambda: None)
+        monkeypatch.setattr(Axes, "axhline", lambda self, y=0, *a, **k: lines.append(y))
+        monkeypatch.setattr(Axes, "axvline", lambda self, x=0, *a, **k: lines.append(x))
+
+        def _capture(*_args, **_kwargs):
+            fig = plt.gcf()
+            legends = list(fig.legends) + [ax.get_legend() for ax in fig.axes if ax.get_legend() is not None]
+            legend_labels.extend(t.get_text() for legend in legends for t in legend.get_texts())
+
+        monkeypatch.setattr(plt, "savefig", _capture)
+        reporter = LeaderboardReporter(output_dir=tmp_path, task_metadata=[])
+        df_elo = pd.DataFrame(
+            {
+                "method": ["GBM (default)", "GBM (tuned + ensemble)", "TabPFN-3"],
+                "elo": [1000.0, 1100.0, 1300.0],
+                "elo+": [10.0, 10.0, 10.0],
+                "elo-": [10.0, 10.0, 10.0],
+            }
+        )
+        reporter.plot_tuning_impact(
+            df=df_elo,
+            df_elo=df_elo,
+            framework_types=["GBM"],
+            baselines=["TabPFN-3"],
+            baseline_colors=["#000000"],
+            save_prefix=str(tmp_path),
+            **kwargs,
+        )
+        return legend_labels, len(lines)
+
+    def test_default_draws_systems_as_bars(self, monkeypatch, tmp_path):
+        labels, n_lines = self._render(monkeypatch, tmp_path)
+        assert "System / Portfolio" in labels
+        assert n_lines == 0
+
+    def test_opt_out_restores_reference_lines(self, monkeypatch, tmp_path):
+        labels, n_lines = self._render(monkeypatch, tmp_path, baselines_as_bars=False)
+        assert "System / Portfolio" not in labels
+        assert n_lines == 1


### PR DESCRIPTION
## Summary

`plot_tuning_impact` now defaults to `baselines_as_bars=True`, so systems and portfolios appear as their own Elo bars next to the model families instead of as dashed reference lines. The switch itself came in with #474; nothing in the `eval` path turned it on, so every leaderboard figure still drew the systems as lines. Passing `baselines_as_bars=False` restores the lines.

<details>
<summary>Details</summary>

The bar rendering reuses the existing `TuneMethodOverride(promote_from_baselines=True)` path: each baseline is moved out of the reference-line list and into the sorted bar order under a "System / Portfolio" legend entry. Only the default value and the comment describing it change; the opt-out keeps the previous figure available for callers that want it.

Because the website artifact generation calls the same plot without overriding the flag, the next leaderboard regeneration will also show systems as bars.

Two new tests render a minimal Elo table with one system through `plot_tuning_impact`. One checks that the default produces the system legend entry and draws no reference line, the other that the opt-out draws exactly one line and no system bar.

</details>

## Tests

```
ruff check packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py tests/tabarena/evaluation/test_leaderboard_reporter.py
ruff format --check packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py tests/tabarena/evaluation/test_leaderboard_reporter.py
pytest tests/tabarena/evaluation/test_leaderboard_reporter.py -q
```

The reporter module reports three ruff findings (two `PLR0917`, one `RUF036`) that are identical on `main` and untouched here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
