### PR TITLE
Aggregate every column in one groupby in GroupAggregationFeatureGenerator

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
@@ -17,7 +17,6 @@ from autogluon.common.features.types import (
     S_TEXT_SPECIAL,
 )
 from autogluon.features import AbstractFeatureGenerator
-from tqdm import tqdm
 
 GROUP_INDEX_FEATURES = "group_index_features"
 
@@ -91,32 +90,29 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
 
         group_key = self._build_group_key(X)
         feature_cols = [c for c in X.columns if c not in self.group_col]
-        num_cols = [c for c in feature_cols if pd.api.types.is_numeric_dtype(X[c])]
-        cat_cols = [c for c in feature_cols if not pd.api.types.is_numeric_dtype(X[c])]
-        time_cols = [self.group_time_on] if self.group_time_on and self.group_time_on in X.columns else []
+        sources = {
+            c: list(self._NUM_AGGS if pd.api.types.is_numeric_dtype(X[c]) else self._CAT_AGGS) for c in feature_cols
+        }
 
-        # Compute all per-group aggregations and select the top n_top_features
-        # by variance (unsupervised).  Categorical aggregations are encoded as
-        # integer category codes before computing variance.
-        variance: dict[str, float] = {}
-        feature_source: dict[str, tuple[str, str, bool]] = {}
-
-        col_iter = [(c, True, list(self._NUM_AGGS)) for c in num_cols] + [
-            (c, False, list(self._CAT_AGGS)) for c in cat_cols
-        ]
-        for col, is_num, aggs in tqdm(col_iter, desc="Computing groupby aggregations", unit="col"):
-            slice_cols = list(dict.fromkeys(self.group_col + time_cols + [col]))
-            X_col = self._sort_by_time(X[slice_cols])
-            agg_df = X_col.groupby(self._build_group_key(X_col), observed=True)[[col]].agg(aggs)
-            agg_df.columns = [f"{col}_{a}" for a in aggs]
-            for feat in agg_df.columns:
-                s = group_key.map(agg_df[feat])
-                if not pd.api.types.is_numeric_dtype(s):
-                    s = s.astype("category").cat.codes.astype(float)
-                    s[s < 0] = np.nan
-                variance[feat] = float(s.var())
-            for agg in aggs:
-                feature_source[f"{col}_{agg}"] = (col, agg, is_num)
+        # Every aggregation of every column in one pass, then the top n_top_features by
+        # variance (unsupervised). Categorical aggregations are encoded as integer category
+        # codes before computing variance.
+        aggregated = self._aggregate(X, sources)
+        mapped = aggregated.reindex(group_key.to_numpy())
+        mapped.index = X.index
+        numeric_features = [f for f in mapped.columns if pd.api.types.is_numeric_dtype(mapped[f])]
+        variance: dict[str, float] = {f: float(v) for f, v in mapped[numeric_features].var().items()}
+        for feat in mapped.columns:
+            if feat in variance:
+                continue
+            s = mapped[feat].astype("category").cat.codes.astype(float)
+            s[s < 0] = np.nan
+            variance[feat] = float(s.var())
+        feature_source = {
+            f"{col}_{agg}": (col, agg, agg in self._NUM_AGGS and pd.api.types.is_numeric_dtype(X[col]))
+            for col, aggs in sources.items()
+            for agg in aggs
+        }
 
         # Select top n_top_features by variance (descending), tie-break by name.
         ranked = sorted(variance.keys(), key=lambda f: (-variance[f], f))
@@ -147,10 +143,8 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         group_key = self._build_group_key(X)
         X = X.drop(columns=self.group_col)
 
-        mapped = pd.DataFrame(
-            {col: group_key.map(X_agg[col]) for col in self._selected_features},
-            index=X.index,
-        )
+        mapped = X_agg[self._selected_features].reindex(group_key.to_numpy())
+        mapped.index = X.index
         return pd.concat([X, mapped], axis=1)
 
     def _sort_by_time(self, X: pd.DataFrame) -> pd.DataFrame:
@@ -170,29 +164,34 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
 
     def _compute_selected_agg_features(self, X: pd.DataFrame) -> pd.DataFrame:
         """Compute only the aggregations needed for the selected features."""
-        X = self._sort_by_time(X)
-        group_key = self._build_group_key(X)
-        parts: list[pd.DataFrame] = []
+        sources = {
+            col: aggs
+            for agg_map in (self._num_agg_map, self._cat_agg_map)
+            for col, aggs in agg_map.items()
+            if col in X.columns
+        }
+        return self._aggregate(X, sources)
 
-        if self._num_agg_map:
-            for col, aggs in self._num_agg_map.items():
-                if col not in X.columns:
-                    continue
-                agg_df = X.groupby(group_key, observed=True)[[col]].agg(aggs)
-                agg_df.columns = [f"{col}_{a}" for a in aggs]
-                parts.append(agg_df)
+    def _aggregate(self, X: pd.DataFrame, sources: dict[str, list[str]]) -> pd.DataFrame:
+        """Per-group values of every ``sources`` aggregation, one row per group.
 
-        if self._cat_agg_map:
-            for col, aggs in self._cat_agg_map.items():
-                if col not in X.columns:
-                    continue
-                agg_df = X.groupby(group_key, observed=True)[[col]].agg(aggs)
-                agg_df.columns = [f"{col}_{a}" for a in aggs]
-                parts.append(agg_df)
-
-        if not parts:
+        One ``groupby`` per distinct aggregation list rather than one per column: the
+        rows are ordered by ``group_time_on`` once (so ``last`` is the latest
+        observation), and the resulting ``(column, aggregation)`` columns are named
+        ``<column>_<aggregation>``. Empty ``sources`` gives an empty frame.
+        """
+        if not sources:
             return pd.DataFrame()
-
+        X_sorted = self._sort_by_time(X)
+        group_key = self._build_group_key(X_sorted)
+        by_aggs: dict[tuple[str, ...], list[str]] = defaultdict(list)
+        for col, aggs in sources.items():
+            by_aggs[tuple(aggs)].append(col)
+        parts: list[pd.DataFrame] = []
+        for aggs, cols in by_aggs.items():
+            agg_df = X_sorted[cols].groupby(group_key, observed=True).agg(list(aggs))
+            agg_df.columns = [f"{col}_{agg}" for col, agg in agg_df.columns]
+            parts.append(agg_df)
         return pd.concat(parts, axis=1)
 
     def _build_group_key(self, X: pd.DataFrame) -> pd.Series:

--- a/tests/tabarena/benchmark/preprocessing/test_preprocessing.py
+++ b/tests/tabarena/benchmark/preprocessing/test_preprocessing.py
@@ -1938,3 +1938,92 @@ class TestGroupAggregationFeatureGenerator:
         # All categorical aggs for cat_c
         assert "cat_c" in gen._cat_agg_map
         assert set(gen._cat_agg_map["cat_c"]) == {"count", "last", "nunique"}
+
+
+def _reference_group_aggregation(
+    gen: GroupAggregationFeatureGenerator, X: pd.DataFrame
+) -> tuple[list[str], pd.DataFrame]:
+    """The column-by-column computation the generator used before aggregating in one pass.
+
+    Returns the selected features and the fitted output frame.
+    """
+    group_key = gen._build_group_key(X)
+    feature_cols = [c for c in X.columns if c not in gen.group_col]
+    num_cols = [c for c in feature_cols if pd.api.types.is_numeric_dtype(X[c])]
+    cat_cols = [c for c in feature_cols if not pd.api.types.is_numeric_dtype(X[c])]
+    time_cols = [gen.group_time_on] if gen.group_time_on and gen.group_time_on in X.columns else []
+    variance: dict[str, float] = {}
+    agg_frames: dict[str, pd.Series] = {}
+    col_iter = [(c, list(gen._NUM_AGGS)) for c in num_cols] + [(c, list(gen._CAT_AGGS)) for c in cat_cols]
+    for col, aggs in col_iter:
+        slice_cols = list(dict.fromkeys(gen.group_col + time_cols + [col]))
+        X_col = gen._sort_by_time(X[slice_cols])
+        agg_df = X_col.groupby(gen._build_group_key(X_col), observed=True)[[col]].agg(aggs)
+        agg_df.columns = [f"{col}_{a}" for a in aggs]
+        for feat in agg_df.columns:
+            s = group_key.map(agg_df[feat])
+            agg_frames[feat] = s
+            if not pd.api.types.is_numeric_dtype(s):
+                s = s.astype("category").cat.codes.astype(float)
+                s[s < 0] = np.nan
+            variance[feat] = float(s.var())
+    ranked = sorted(variance.keys(), key=lambda f: (-variance[f], f))
+    selected = ranked[: gen.n_top_features]
+    mapped = pd.DataFrame({f: agg_frames[f] for f in selected}, index=X.index)
+    return selected, pd.concat([X.drop(columns=gen.group_col), mapped], axis=1)
+
+
+def _random_grouped_frame(rng: np.random.Generator) -> tuple[pd.DataFrame, list[str] | str, str | None]:
+    n_groups = int(rng.integers(2, 7))
+    rows = np.repeat(np.arange(n_groups), rng.integers(1, 6, size=n_groups))
+    rng.shuffle(rows)
+    n = len(rows)
+    X = pd.DataFrame({"g1": rows, "g2": rows % 2})
+    for i in range(int(rng.integers(1, 5))):
+        kind = rng.integers(5)
+        if kind == 0:
+            col = rng.normal(size=n)
+            col[rng.random(n) < 0.2] = np.nan
+        elif kind == 1:
+            col = rng.integers(0, 4, size=n)
+        elif kind == 2:
+            col = rng.integers(0, 2, size=n).astype(bool)
+        elif kind == 3:
+            col = pd.Categorical(rng.choice(["a", "b", "c"], size=n))
+        else:
+            col = rng.choice(np.array(["x", "y", None], dtype=object), size=n)
+        X[f"f{i}_{kind}"] = col
+    if rng.random() < 0.5:
+        X["t"] = rng.integers(0, 3, size=n)  # ties on purpose
+        time_on = "t"
+    else:
+        time_on = None
+    group_col = ["g1", "g2"] if rng.random() < 0.3 else "g1"
+    return X, group_col, time_on
+
+
+@pytest.mark.parametrize("seed", range(60))
+def test_group_aggregation_one_pass_matches_per_column(seed: int) -> None:
+    """Aggregating every column in one groupby selects and produces what the per-column pass did."""
+    rng = np.random.default_rng(seed)
+    X, group_col, time_on = _random_grouped_frame(rng)
+    n_top = int(rng.choice([1, 3, 7, 100]))
+    gen = GroupAggregationFeatureGenerator(group_col=group_col, group_time_on=time_on, n_top_features=n_top)
+    expected_selected, expected_out = _reference_group_aggregation(gen, X.copy())
+    got_out, _ = gen._fit_transform(X.copy(), pd.Series(np.zeros(len(X))))
+    assert gen._selected_features == expected_selected
+    assert list(got_out.columns) == list(expected_out.columns)
+    for col in expected_out.columns:
+        a, b = got_out[col], expected_out[col]
+        if pd.api.types.is_numeric_dtype(b):
+            np.testing.assert_allclose(a.to_numpy(dtype=float), b.to_numpy(dtype=float), rtol=0, atol=0, equal_nan=True)
+        else:
+            assert (
+                a.astype(object).where(a.notna(), None).tolist() == b.astype(object).where(b.notna(), None).tolist()
+            ), col
+    # transform on a frame with an unseen group summarises it from its own rows, as before
+    X_new = X.copy()
+    X_new["g1"] = X_new["g1"] + 100
+    transformed = gen._transform(X_new.copy())
+    assert list(transformed.columns) == list(expected_out.columns)
+    assert transformed.index.equals(X_new.index)


### PR DESCRIPTION
`GroupAggregationFeatureGenerator` ran one `groupby` per column at fit, each on its own column slice sorted by `group_time_on`, and mapped every aggregate back to the rows one Series at a time. On a label-per-group task with several thousand columns that was almost all of the model-agnostic pipeline's fit time (about 11.5 s of 12.7 s on a 6,772-column frame with 180 rows).

The rows are now ordered by `group_time_on` once, every column sharing an aggregation list is aggregated in a single `groupby(...).agg`, and all aggregates are mapped back with one `reindex`; the same helper serves fit and transform, so transform also stops looping per source column. The variance ranking, the tie-break by name, the selected features, the per-source aggregation maps and the categorical-codes variance path are unchanged, and the `tqdm` loop is gone.

A 60-seed randomized test compares the selected features and the full output frame against the previous per-column computation (copied into the test as the reference) on frames mixing float with NaN, int, bool, categorical and object columns, with and without `group_time_on` including ties, single and composite keys, and several `n_top_features`; it also checks transform on unseen groups. On the frame above the fit goes from 12.7 s to 4.0 s with identical predictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
