### PR TITLE
Collect the best model's get_info once in AGSingleWrapper.get_metadata

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/exec_models/autogluon.py
+++ b/packages/tabarena/src/tabarena/benchmark/exec_models/autogluon.py
@@ -423,6 +423,22 @@ class AGWrapper(AbstractExecModel):
                 torch.cuda.empty_cache()
 
 
+def _hyperparameters_user_from_info(info: dict) -> dict:
+    """The user-specified hyperparameters of a model, read from its ``get_info()`` output.
+
+    Same result as ``TabularPredictor.model_hyperparameters(model, output_format="user")``,
+    which computes a fresh ``get_info()`` internally; this reads an already collected one. For a
+    bagged model the child's hyperparameters are returned, with the bag's own under
+    ``ag_args_ensemble`` when any were given.
+    """
+    if "bagged_info" in info:
+        hyperparameters = info["bagged_info"]["child_hyperparameters_user"].copy()
+        if info["hyperparameters_user"]:
+            hyperparameters["ag_args_ensemble"] = info["hyperparameters_user"]
+        return hyperparameters
+    return info["hyperparameters_user"]
+
+
 class AGSingleWrapper(AGWrapper):
     """Fit a single AutoGluon model (no weighted ensemble) inside a ``TabularPredictor``.
 
@@ -517,9 +533,17 @@ class AGSingleWrapper(AGWrapper):
         """Capture any model fit failures so the runner can record them on a crash."""
         self.failure_artifact = self.get_metadata_failure()
 
-    def get_hyperparameters(self) -> dict:
-        """Return the best model's hyperparameters in user-facing form."""
-        return self.predictor.model_hyperparameters(model=self.predictor.model_best, output_format="user")
+    def get_hyperparameters(self, info: dict | None = None) -> dict:
+        """Return the best model's hyperparameters in user-facing form.
+
+        ``info`` is the best model's ``get_info()`` output. ``get_metadata`` passes the one it
+        already collected, because ``get_info`` on a bagged model reloads its children from disk
+        and pickles every model to measure its size, which for a foundation model means
+        serialising the weights.
+        """
+        if info is None:
+            info = self._load_model(assert_single_model=False).get_info(include_feature_metadata=False)
+        return _hyperparameters_user_from_info(info)
 
     @property
     def model_cls(self) -> type[AbstractModel]:
@@ -549,10 +573,13 @@ class AGSingleWrapper(AGWrapper):
             model_name = self.predictor.model_best
         return self.predictor._trainer.load_model(model_name)
 
-    def get_metadata_init(self) -> dict:
-        """Metadata known at construction time (model class, hyperparameters, extra kwargs)."""
+    def get_metadata_init(self, info: dict | None = None) -> dict:
+        """Metadata known at construction time (model class, hyperparameters, extra kwargs).
+
+        ``info`` is the best model's ``get_info()`` output, see ``get_hyperparameters``.
+        """
         metadata = {}
-        metadata["hyperparameters"] = self.get_hyperparameters()
+        metadata["hyperparameters"] = self.get_hyperparameters(info=info)
         metadata["model_cls"] = self.model_cls.__name__
         metadata["model_type"] = self.model_cls.ag_key
         metadata["name_prefix"] = self.model_cls.ag_name
@@ -561,15 +588,22 @@ class AGSingleWrapper(AGWrapper):
         metadata["fit_kwargs_extra"] = self.fit_kwargs_extra
         return metadata
 
-    def get_metadata_fit(self) -> dict:
-        """Metadata available only after fitting (info, disk/compute usage, fit metadata)."""
+    def get_metadata_fit(self, model: AbstractModel | None = None, info: dict | None = None) -> dict:
+        """Metadata available only after fitting (info, disk/compute usage, fit metadata).
+
+        ``model`` is the loaded best model and ``info`` its ``get_info()`` output; either is
+        collected here when not given.
+        """
         metadata = {}
         # Persist outcome: which models were in memory during the timed inference
         # (None = persist disabled or inference not run; [] = skipped by the memory guard).
         metadata["persist"] = self.persist
         metadata["persisted_models"] = self._persisted_models
-        model = self._load_model(assert_single_model=False)
-        metadata["info"] = model.get_info(include_feature_metadata=False)
+        if model is None:
+            model = self._load_model(assert_single_model=False)
+        if info is None:
+            info = model.get_info(include_feature_metadata=False)
+        metadata["info"] = info
         metadata["disk_usage"] = model.disk_usage()
         metadata["num_cpus"] = model.fit_num_cpus
         metadata["num_gpus"] = model.fit_num_gpus
@@ -587,11 +621,14 @@ class AGSingleWrapper(AGWrapper):
         }
 
     def get_metadata(self) -> dict:
-        """Combined construction-time and post-fit metadata for this model."""
-        metadata = self.get_metadata_init()
-        metadata_fit = self.get_metadata_fit()
+        """Combined construction-time and post-fit metadata for this model.
 
-        metadata.update(metadata_fit)
+        The best model is loaded and its ``get_info()`` collected once, then shared by both parts.
+        """
+        model = self._load_model(assert_single_model=False)
+        info = model.get_info(include_feature_metadata=False)
+        metadata = self.get_metadata_init(info=info)
+        metadata.update(self.get_metadata_fit(model=model, info=info))
         return metadata
 
 

--- a/tests/tabarena/benchmark/exec_models/test_autogluon.py
+++ b/tests/tabarena/benchmark/exec_models/test_autogluon.py
@@ -1,0 +1,137 @@
+"""Tests for ``AGSingleWrapper``'s post-fit metadata collection.
+
+A fake predictor/trainer stands in for AutoGluon; only the metadata bookkeeping is under test,
+in particular that the best model's ``get_info()`` is collected once and read consistently.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from autogluon.core.metrics import get_metric
+from autogluon.core.models import AbstractModel
+
+from tabarena.benchmark.exec_models.autogluon import AGSingleWrapper, _hyperparameters_user_from_info
+
+
+class _DummyModel(AbstractModel):
+    ag_key = "DUMMYMETADATAMODEL"
+    ag_name = "DummyMetadataModel"
+
+
+class _FakeFittedModel:
+    """Loaded best model; counts the (expensive) ``get_info`` calls."""
+
+    fit_num_cpus = 4
+    fit_num_gpus = 1
+    fit_num_cpus_child = 2
+    fit_num_gpus_child = 0.5
+    _memory_usage_estimate = 12345
+
+    def __init__(self, info: dict):
+        self._info = info
+        self.get_info_calls = 0
+
+    def get_info(self, include_feature_metadata: bool = True) -> dict:
+        assert include_feature_metadata is False
+        self.get_info_calls += 1
+        return self._info
+
+    def disk_usage(self) -> int:
+        return 42
+
+    def get_fit_metadata(self) -> dict:
+        return {"fit": "metadata"}
+
+
+class _FakePredictor:
+    def __init__(self, model: _FakeFittedModel):
+        self.model_best = "Dummy_BAG_L1"
+        self._trainer = SimpleNamespace(load_model=lambda name: model, models={})
+        self.load_model_calls = 0
+        trainer_load = self._trainer.load_model
+
+        def counted(name):
+            assert name == self.model_best
+            self.load_model_calls += 1
+            return trainer_load(name)
+
+        self._trainer.load_model = counted
+
+    def model_names(self, can_infer: bool = False) -> list[str]:
+        return [self.model_best]
+
+    def model_hyperparameters(self, *args, **kwargs):
+        raise AssertionError("get_metadata must read hyperparameters from the collected info")
+
+
+BAGGED_INFO = {
+    "hyperparameters_user": {"model_random_seed": 3},
+    "bagged_info": {"child_hyperparameters_user": {"n_estimators": 8}},
+}
+BAGGED_INFO_NO_ENSEMBLE_ARGS = {
+    "hyperparameters_user": {},
+    "bagged_info": {"child_hyperparameters_user": {"n_estimators": 8}},
+}
+SINGLE_INFO = {"hyperparameters_user": {"n_estimators": 8}}
+
+
+def _make_wrapper(model: _FakeFittedModel) -> AGSingleWrapper:
+    wrapper = AGSingleWrapper(
+        model_cls=_DummyModel,
+        model_hyperparameters={"n_estimators": 8},
+        problem_type="regression",
+        eval_metric=get_metric("rmse", problem_type="regression"),
+    )
+    wrapper.predictor = _FakePredictor(model)
+    return wrapper
+
+
+class TestHyperparametersUserFromInfo:
+    def test_bagged_appends_ensemble_args(self):
+        assert _hyperparameters_user_from_info(BAGGED_INFO) == {
+            "n_estimators": 8,
+            "ag_args_ensemble": {"model_random_seed": 3},
+        }
+
+    def test_bagged_without_ensemble_args(self):
+        assert _hyperparameters_user_from_info(BAGGED_INFO_NO_ENSEMBLE_ARGS) == {"n_estimators": 8}
+
+    def test_bagged_does_not_mutate_info(self):
+        info = {
+            "hyperparameters_user": {"model_random_seed": 3},
+            "bagged_info": {"child_hyperparameters_user": {"n_estimators": 8}},
+        }
+        _hyperparameters_user_from_info(info)
+        assert info["bagged_info"]["child_hyperparameters_user"] == {"n_estimators": 8}
+
+    def test_single_model(self):
+        assert _hyperparameters_user_from_info(SINGLE_INFO) == {"n_estimators": 8}
+
+
+class TestGetMetadata:
+    def test_collects_info_once_and_shares_it(self):
+        model = _FakeFittedModel(BAGGED_INFO)
+        wrapper = _make_wrapper(model)
+
+        metadata = wrapper.get_metadata()
+
+        assert model.get_info_calls == 1
+        assert wrapper.predictor.load_model_calls == 1
+        assert metadata["info"] is BAGGED_INFO
+        assert metadata["hyperparameters"] == {"n_estimators": 8, "ag_args_ensemble": {"model_random_seed": 3}}
+        assert metadata["model_cls"] == "_DummyModel"
+        assert metadata["model_type"] == "DUMMYMETADATAMODEL"
+        assert metadata["disk_usage"] == 42
+        assert metadata["num_cpus_child"] == 2
+        assert metadata["fit_metadata"] == {"fit": "metadata"}
+        assert metadata["memory_usage_estimate"] == 12345
+
+    def test_parts_collect_info_themselves_when_not_given(self):
+        model = _FakeFittedModel(SINGLE_INFO)
+        wrapper = _make_wrapper(model)
+
+        assert wrapper.get_hyperparameters() == {"n_estimators": 8}
+        assert wrapper.get_metadata_init()["hyperparameters"] == {"n_estimators": 8}
+        assert wrapper.get_metadata_fit()["info"] is SINGLE_INFO
+        assert model.get_info_calls == 3


### PR DESCRIPTION
## Summary

`AGSingleWrapper.get_metadata` called the best model's `get_info` twice, once through `TabularPredictor.model_hyperparameters` and once for the fit metadata. Each call reloads a bagged model's children from disk and pickles every model to measure its size, which for a foundation model serialises the weights. The model is now loaded and its `get_info` collected once, and the hyperparameters are read from that dict with the same result as `model_hyperparameters(output_format="user")`.

<details>
<summary>Details</summary>

`get_hyperparameters`, `get_metadata_init` and `get_metadata_fit` accept the loaded model and/or its `info` and collect them themselves when not given, so they keep working standalone. `_hyperparameters_user_from_info` mirrors the `output_format="user"` branch of `TabularPredictor.model_hyperparameters`, which has no way to take an already collected info dict.

Checked on a bagged fit with `refit_folds=True`: hyperparameters and info (minus per-call timings and `memory_size`) are identical to the old two-pass path; the metadata step went from 1.26 s to 0.61 s per task on a small dataset, where the fit itself takes about 1.5 s.

</details>

## Tests

```
ruff check --fix packages/tabarena/src/tabarena/benchmark/exec_models/autogluon.py tests/tabarena/benchmark/exec_models/
ruff format packages/tabarena/src/tabarena/benchmark/exec_models/autogluon.py tests/tabarena/benchmark/exec_models/
pytest tests/tabarena/benchmark/exec_models/test_autogluon.py tests/tabarena/benchmark/experiment/test_persist_inference.py -q
```

16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
