### PR TITLE
Define BeyondArena size buckets on the largest training split

### DIFF
--- a/examples/beyondarena/README.md
+++ b/examples/beyondarena/README.md
@@ -92,7 +92,7 @@ of predicates (see `BeyondArenaContext.SUBSET_PREDICATES`):
 | Group | Predicates | Meaning |
 |---|---|---|
 | **Problem type** | `binary`, `multiclass`, `classification`, `regression` | The task's target type. |
-| **Size bucket** | `tiny`, `small`, `medium`, `large` | By `max_train_rows`: tiny ≤ 1k, small ≤ 10k, medium ≤ 100k, large ≤ 1M. |
+| **Size bucket** | `tiny`, `small`, `medium`, `large` | By `max_train_rows`, the largest training-split size of a dataset (bounds inclusive): tiny 101 to 1k, small 1,001 to 10k, medium 10,001 to 100k, large above 100k. |
 | **Split regime** | `iid` (alias `random`), `temporal`, `grouped` | How the splits are drawn — the *beyond-IID* axis. |
 | **Features** | `low-dim`, `high-dim`, `text`, `high-cardinality` | `low/high-dim` split at 100 cols after preprocessing; `text`/`high-cardinality` keep datasets that have such columns. |
 | **Split** | `core`, `lite`, `all` | `core` = each dataset's first `folds_to_use` splits (**the recommended default — use this**); `lite` = the first split only (fast smoke test); `all` = every split (rarely needed — `core` is enough). |

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
@@ -509,9 +509,8 @@ class TaskMetadataCollection:
 
         Uses native column names (``problem_type``, ``num_features``, ``num_classes``, ...)
         plus a ``dataset`` key column, ``max_train_rows`` — the per-dataset *maximum*
-        training-fold size over splits, which the BeyondArena size predicates key on (note
-        :meth:`task_grid`'s ``max_train_rows`` is the per-dataset *mean*, matching the
-        legacy schema) — and ``n_splits``, the total split count per dataset.
+        training-fold size over splits, which the size predicates key on (the same value
+        :meth:`task_grid` carries) — and ``n_splits``, the total split count per dataset.
 
         ``n_splits`` is summed across every task for a dataset because it is the
         :class:`~tabarena.benchmark.task.metadata.schema.TabArenaTaskMetadata.n_splits`
@@ -550,9 +549,11 @@ class TaskMetadataCollection:
         * ``split`` — ``n_folds * repeat + fold`` (``n_folds`` = max fold + 1 per dataset); this is
           what ``"lite"`` keys on (``split == 0``) and what a results frame's ``fold`` column maps
           to when subsetting.
-        * predicate columns, using the predicate-facing names: ``max_train_rows`` (mean per-fold
-          train size over the dataset's splits — matches :meth:`to_legacy_df`'s
-          ``n_samples_train_per_fold``), ``n_features`` (``num_features``), ``n_classes``
+        * predicate columns, using the predicate-facing names: ``max_train_rows`` (the per-dataset
+          *maximum* training-fold size over the dataset's splits, same as
+          :meth:`per_dataset_frame`; for temporal and grouped splits the training size varies per
+          split, and the size buckets are defined on the largest one), ``n_features``
+          (``num_features``), ``n_classes``
           (``num_classes``), ``problem_type``, and the warehouse fields ``task_type``,
           ``num_cols_after_preprocessing``, ``num_text_cols``, ``num_high_cardinality_cats``,
           ``has_categorical``, ``has_datetime``, ``group_labels`` (``None`` for tasks that
@@ -574,7 +575,7 @@ class TaskMetadataCollection:
         }
         cols = ["dataset", "fold", "repeat", "split", "max_train_rows", *grid_col_to_field]
         n_folds_by_dataset: dict[str, int] = {}
-        train_sizes: dict[str, list[float]] = {}
+        train_sizes: dict[str, list[int]] = {}
         meta: dict[str, dict] = {}
         for t in self._tasks:
             ds = t.tabarena_task_name
@@ -582,14 +583,14 @@ class TaskMetadataCollection:
             for split in t.splits_metadata.values():
                 n_folds_by_dataset[ds] = max(n_folds_by_dataset.get(ds, 0), split.fold + 1)
                 train_sizes.setdefault(ds, []).append(split.num_instances_train)
-        mean_train = {ds: (sum(sizes) / len(sizes)) for ds, sizes in train_sizes.items()}
+        max_train = {ds: max(sizes) for ds, sizes in train_sizes.items()}
         rows = [
             {
                 "dataset": ds,
                 "fold": fold,
                 "repeat": repeat,
                 "split": n_folds_by_dataset[ds] * repeat + fold,
-                "max_train_rows": mean_train[ds],
+                "max_train_rows": max_train[ds],
                 **meta[ds],
             }
             for ds, fold, repeat in self.dataset_fold_repeats()

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/schema.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/schema.py
@@ -520,9 +520,12 @@ def to_legacy_task_metadata(task_metadata: list[TabArenaTaskMetadata]) -> pd.Dat
     * ``n_folds`` / ``n_repeats`` — *aggregate* per-dataset split counts, used to expand
       the (dataset, fold, repeat) grid.
     * ``problem_type``, ``n_features``, ``n_classes``, ``n_samples_train_per_fold`` — the
-      columns the subset predicates reference. ``n_samples_train_per_fold`` is aliased to
-      ``max_train_rows`` when the legacy frame is expanded into the subset task grid
-      (``compare._task_grid_from_legacy_df``) for the size buckets.
+      columns the subset predicates reference. ``n_samples_train_per_fold`` is the *mean*
+      per-fold train size; ``compare._task_grid_from_legacy_df`` aliases it to ``max_train_rows``
+      when a legacy frame is expanded into the subset task grid, which is exact only when every
+      split has the same train size (IID k-fold, i.e. what legacy frames describe). Collections
+      evaluate the size buckets on :meth:`TaskMetadataCollection.task_grid`, whose
+      ``max_train_rows`` is the true per-dataset maximum.
 
     Two things make this a non-trivial mapping (see :func:`TabArenaTaskMetadata.to_dataframe`):
 
@@ -550,7 +553,8 @@ def to_legacy_task_metadata(task_metadata: list[TabArenaTaskMetadata]) -> pd.Dat
     # n_samples_*_per_fold is the mean per-fold size, kept as a float: it matches the curated
     # per-fold average and is the exact inverse of from_legacy_df (which stamps one per-fold
     # value onto every split), so the conversion round-trips without max()/int() loss.
-    # (NB: the subset predicates alias n_samples_train_per_fold to ``max_train_rows``.)
+    # (NB: compare._task_grid_from_legacy_df aliases n_samples_train_per_fold to ``max_train_rows``
+    # for legacy-frame inputs, where equal fold sizes make the mean and the max coincide.)
     aggregates = per_split.groupby("dataset", sort=False).agg(
         n_folds=("fold", "nunique"),
         n_repeats=("repeat", "nunique"),

--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -232,7 +232,9 @@ def _task_grid_from_legacy_df(task_metadata: pd.DataFrame) -> pd.DataFrame:
     legacy ``task_metadata`` DataFrame, by expanding the rectangular ``n_folds`` x ``n_repeats``
     grid per dataset. Mirrors :meth:`TaskMetadataCollection.task_grid` for the legacy input path
     (requires ``dataset``/``n_folds``/``n_repeats``; aliases ``n_samples_train_per_fold`` to
-    ``max_train_rows``).
+    ``max_train_rows``). The alias is exact only when every split of a dataset has the same train
+    size (IID k-fold); a legacy frame carries no per-split sizes, so it cannot recover the maximum
+    that :meth:`TaskMetadataCollection.task_grid` reports for temporal or grouped splits.
     """
     md = task_metadata.drop_duplicates("dataset").copy()
     if "max_train_rows" not in md.columns and "n_samples_train_per_fold" in md.columns:

--- a/tests/tabarena/benchmark/task/test_task_metadata_collection.py
+++ b/tests/tabarena/benchmark/task/test_task_metadata_collection.py
@@ -151,6 +151,20 @@ class TestNativeViews:
         assert frame.loc["a", "max_train_rows"] == 200
         assert frame.loc["b", "max_train_rows"] == 80
 
+    def test_task_grid_max_train_rows_is_max_over_splits(self):
+        # The grid is what the size buckets are evaluated on, so it must carry the same per-dataset
+        # maximum as per_dataset_frame. A mean would drop a temporal dataset whose training split
+        # shrinks across repeats into a smaller bucket than its largest split belongs to.
+        splits = [_split_meta(fold=f, num_instances_train=size) for f, size in enumerate([50, 200, 110])]
+        tasks = _unrolled(_task_meta(dataset_name="a", splits=splits))
+        tasks += _unrolled(_task_meta(dataset_name="b"))  # single split of 80
+        collection = TaskMetadataCollection(tasks)
+        grid = collection.task_grid()
+        assert (grid.loc[grid["dataset"] == "a", "max_train_rows"] == 200).all()
+        assert (grid.loc[grid["dataset"] == "b", "max_train_rows"] == 80).all()
+        per_dataset = collection.per_dataset_frame().set_index("dataset")["max_train_rows"]
+        assert (grid["max_train_rows"].to_numpy() == per_dataset.loc[grid["dataset"]].to_numpy()).all()
+
 
 def _legacy_row(
     *,

--- a/tests/tabarena/contexts/test_beyond_arena.py
+++ b/tests/tabarena/contexts/test_beyond_arena.py
@@ -78,3 +78,32 @@ def test_subset_shortcut_name_matches_negated_expressions():
     assert BeyondArenaContext.subset_shortcut_name(["!large", "core", "lite", "high-cardinality"]) == "hc_nolarge_lite"
     assert BeyondArenaContext.subset_shortcut_name(["core", "high-cardinality"]) == "high_cardinality"
     assert BeyondArenaContext.subset_shortcut_name(["core", "!large"]) is None
+
+
+def test_size_buckets_partition_datasets_by_largest_training_split():
+    """The size buckets are defined on each dataset's largest training split.
+
+    Temporal datasets have training splits of different sizes. Bucketing on the largest one gives the
+    counts the BeyondArena paper reports (52 tiny, 38 small, 30 medium, 22 large); bucketing on the
+    mean split size would move ``garments_worker_productivity`` to tiny and ``sf_permit_time`` to
+    medium (autogluon/tabarena#523).
+    """
+    from tabarena.benchmark.task.metadata import BeyondArenaTaskMetadataCollection
+
+    collection = BeyondArenaTaskMetadataCollection()
+    predicates = BeyondArenaContext.SUBSET_PREDICATES
+    buckets = {
+        name: set(collection.subset_tasks(subset=[name], predicates=predicates).per_dataset_frame()["dataset"])
+        for name in ("tiny", "small", "medium", "large")
+    }
+    assert {name: len(datasets) for name, datasets in buckets.items()} == {
+        "tiny": 52,
+        "small": 38,
+        "medium": 30,
+        "large": 22,
+    }
+    all_datasets = set(collection.per_dataset_frame()["dataset"])
+    assert set().union(*buckets.values()) == all_datasets
+    assert sum(len(datasets) for datasets in buckets.values()) == len(all_datasets)
+    assert "garments_worker_productivity-7b6a94e87c93" in buckets["small"]
+    assert "sf_permit_time-a3faf4c318ef" in buckets["large"]


### PR DESCRIPTION
## Summary

`TaskMetadataCollection.task_grid()` stored the per-dataset *mean* of the split training sizes under the name `max_train_rows`, so `build_jobs`, `compare` and the website generation bucketed BeyondArena's temporal datasets by their mean training size, while `per_dataset_frame()` and the paper use the largest split. This moved `garments_worker_productivity` to `tiny` and `sf_permit_time` to `medium` and gave 53/37/31/21 datasets per size bucket instead of the paper's 52/38/30/22 (#523). The grid now carries the same per-dataset maximum as `per_dataset_frame()`; the thresholds in `BeyondArenaContext` are unchanged.

Fixes #523

<details>
<summary>Details</summary>

The mean came from round-trip parity with the legacy TabArena-v0.1 column `n_samples_train_per_fold`, a per-fold average. For IID k-fold splits mean and max coincide, so TabArena-v0.1 never exposed the difference; its buckets are unchanged by this PR (every dataset has identical training sizes across its splits). BeyondArena's temporal splits grow or shrink per repeat, and four datasets straddle a bucket boundary across splits; the mean moved two of them one bucket down.

Counts on the committed `BeyondArena_tasks_metadata.csv` with the unchanged `BeyondArenaContext` thresholds:

| aggregate of per-split training rows | tiny | small | medium | large |
|---|---|---|---|---|
| max (paper, `per_dataset_frame`, this PR) | 52 | 38 | 30 | 22 |
| mean (`task_grid` before this PR) | 53 | 37 | 31 | 21 |

`to_legacy_task_metadata` keeps `n_samples_train_per_fold` as the mean (it round-trips through `from_legacy_df`); its alias to `max_train_rows` in `compare._task_grid_from_legacy_df` is exact only for equal fold sizes, which is now documented there and in the schema. The BeyondArena README states the size bands as implemented (inclusive bounds on the largest training split).

Leaderboard: the BeyondArena website artifacts were regenerated with this change and deployed to the live Space in [commit 34272b64](https://huggingface.co/spaces/TabArena/leaderboard/commit/34272b64d384755a1c2f7eee1b5ad9971fb521c6) (version history entry v0.1.8.3) and to `leaderboard-testing` in [commit 901ceafe](https://huggingface.co/spaces/TabArena/leaderboard-testing/commit/901ceafe2284875d5dbb340e6cf14af38b4e73d1). The tiny/small/medium/large tabs now report 52/38/30/22 datasets; the other subsets are unchanged apart from regenerated figures.

The second commit makes `run_generate_beyondarena_website_artifacts.py` emit the per-subset `leaderboard_table.html` the Space embeds (only the TabArena converter did, so a BeyondArena refresh dropped the twelve files and the app fell back to its own table).

</details>

## Tests

```
ruff check <touched files> && ruff format --check <touched files>   # ruff 0.14.0 (CI pin) and 0.16.1
pytest tests/tabarena/benchmark/task/test_task_metadata_collection.py tests/tabarena/benchmark/task/test_collection_subset_tasks.py tests/tabarena/contexts/test_beyond_arena.py tests/tabarena/contexts/test_beyond_arena_context.py tests/tabarena/contexts/test_tabarena_context.py tests/tabarena/nips2025_utils/test_subset_tasks.py tests/tabarena/evaluation/test_beyond_metadata.py -q   # 169 passed
```

New tests: `test_task_grid_max_train_rows_is_max_over_splits` (grid equals `per_dataset_frame` on uneven splits) and `test_size_buckets_partition_datasets_by_largest_training_split` (52/38/30/22 on the committed CSV, the two datasets in their paper buckets).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
