### PR TITLE
Rank group aggregations from the group table instead of a rows x aggregations frame

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
@@ -95,27 +95,33 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         }
 
         # Every aggregation of every column in one pass, then the top n_top_features by
-        # variance (unsupervised). Categorical aggregations are encoded as integer category
-        # codes before computing variance.
+        # variance (unsupervised). The variance is that of each per-group value broadcast to
+        # the rows of its group, computed from the group table and the group sizes rather
+        # than from a rows x aggregations frame: mapping every aggregation back to every row
+        # costs rows x columns x aggregations values, which on a million-row task with a few
+        # hundred columns is tens of gigabytes for a number the group table already holds.
+        # Categorical aggregations are encoded as integer category codes before computing
+        # variance.
         aggregated = self._aggregate(X, sources)
-        mapped = aggregated.reindex(group_key.to_numpy())
-        mapped.index = X.index
-        numeric_features = [f for f in mapped.columns if pd.api.types.is_numeric_dtype(mapped[f])]
-        variance: dict[str, float] = {f: float(v) for f, v in mapped[numeric_features].var().items()}
-        for feat in mapped.columns:
-            if feat in variance:
-                continue
-            s = mapped[feat].astype("category").cat.codes.astype(float)
-            s[s < 0] = np.nan
-            variance[feat] = float(s.var())
+        group_sizes = group_key.value_counts().reindex(aggregated.index).to_numpy(dtype=float)
+        variance: dict[str, float] = {}
+        for feat in aggregated.columns:
+            values = aggregated[feat]
+            if not pd.api.types.is_numeric_dtype(values):
+                values = values.astype("category").cat.codes.astype(float)
+                values[values < 0] = np.nan
+            variance[feat] = self._broadcast_variance(values.to_numpy(dtype=float), group_sizes)
         feature_source = {
             f"{col}_{agg}": (col, agg, agg in self._NUM_AGGS and pd.api.types.is_numeric_dtype(X[col]))
             for col, aggs in sources.items()
             for agg in aggs
         }
 
-        # Select top n_top_features by variance (descending), tie-break by name.
-        ranked = sorted(variance.keys(), key=lambda f: (-variance[f], f))
+        # Select top n_top_features by variance (descending), tie-break by name. The variance
+        # is rounded to 12 significant digits first: two aggregations of the same values (a
+        # column's `count` and another's, say) must rank as a tie by name, not by the last bit
+        # of two floating-point sums.
+        ranked = sorted(variance.keys(), key=lambda f: (-self._rank_variance(variance[f]), f))
         self._selected_features = ranked[: self.n_top_features]
 
         # Build test-time agg maps.
@@ -171,6 +177,26 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
             if col in X.columns
         }
         return self._aggregate(X, sources)
+
+    @staticmethod
+    def _rank_variance(variance: float) -> float:
+        """The variance as the ranking compares it: rounded to 12 significant digits."""
+        return float(f"{variance:.12g}")
+
+    @staticmethod
+    def _broadcast_variance(values: np.ndarray, sizes: np.ndarray) -> float:
+        """Sample variance of ``values[g]`` repeated ``sizes[g]`` times, NaN groups skipped.
+
+        Equals ``pd.Series(values[group_of_row]).var()`` (``ddof=1``) without building that
+        series.
+        """
+        keep = ~np.isnan(values)
+        values, sizes = values[keep], sizes[keep]
+        n = sizes.sum()
+        if n <= 1:
+            return float("nan")
+        mean = (sizes * values).sum() / n
+        return float((sizes * (values - mean) ** 2).sum() / (n - 1))
 
     def _aggregate(self, X: pd.DataFrame, sources: dict[str, list[str]]) -> pd.DataFrame:
         """Per-group values of every ``sources`` aggregation, one row per group.

--- a/tests/tabarena/benchmark/preprocessing/test_preprocessing.py
+++ b/tests/tabarena/benchmark/preprocessing/test_preprocessing.py
@@ -1967,7 +1967,7 @@ def _reference_group_aggregation(
                 s = s.astype("category").cat.codes.astype(float)
                 s[s < 0] = np.nan
             variance[feat] = float(s.var())
-    ranked = sorted(variance.keys(), key=lambda f: (-variance[f], f))
+    ranked = sorted(variance.keys(), key=lambda f: (-gen._rank_variance(variance[f]), f))
     selected = ranked[: gen.n_top_features]
     mapped = pd.DataFrame({f: agg_frames[f] for f in selected}, index=X.index)
     return selected, pd.concat([X.drop(columns=gen.group_col), mapped], axis=1)
@@ -2027,3 +2027,49 @@ def test_group_aggregation_one_pass_matches_per_column(seed: int) -> None:
     transformed = gen._transform(X_new.copy())
     assert list(transformed.columns) == list(expected_out.columns)
     assert transformed.index.equals(X_new.index)
+
+
+class TestGroupAggregationVarianceFromGroupTable:
+    """The feature ranking is computed from the group table, not from a rows x aggregations frame."""
+
+    @staticmethod
+    def _mapped_variance(X: pd.DataFrame, gen: GroupAggregationFeatureGenerator) -> dict[str, float]:
+        """The variance the ranking used to be computed from: every aggregation mapped to every row."""
+        group_key = gen._build_group_key(X)
+        feature_cols = [c for c in X.columns if c not in gen.group_col]
+        sources = {
+            c: list(gen._NUM_AGGS if pd.api.types.is_numeric_dtype(X[c]) else gen._CAT_AGGS) for c in feature_cols
+        }
+        mapped = gen._aggregate(X, sources).reindex(group_key.to_numpy())
+        out = {}
+        for feat in mapped.columns:
+            s = mapped[feat]
+            if not pd.api.types.is_numeric_dtype(s):
+                s = s.astype("category").cat.codes.astype(float)
+                s[s < 0] = np.nan
+            out[feat] = float(s.var())
+        return out
+
+    def test_broadcast_variance_matches_the_mapped_series(self):
+        values = np.array([1.0, np.nan, 3.0, 10.0])
+        sizes = np.array([3.0, 5.0, 1.0, 2.0])
+        rows = np.repeat(values, sizes.astype(int))
+        expected = pd.Series(rows).var()
+        got = GroupAggregationFeatureGenerator._broadcast_variance(values, sizes)
+        assert got == pytest.approx(expected, rel=1e-12)
+        assert np.isnan(
+            GroupAggregationFeatureGenerator._broadcast_variance(np.array([2.0, np.nan]), np.array([1.0, 4.0]))
+        )
+
+    def test_ranking_matches_the_mapped_variance(self):
+        rng = np.random.default_rng(7)
+        X, y = _make_grouped_df(n_groups=40, rows_per_group=6, rng=rng)
+        X.loc[rng.choice(X.index, 30, replace=False), "num_b"] = np.nan  # some groups aggregate to NaN
+        X["gid"] = X["gid"].astype(str)
+        X = X.sample(frac=1.0, random_state=0).reset_index(drop=True)  # unequal, unsorted groups
+        X.loc[X.index[:50], "gid"] = "0"
+        gen = GroupAggregationFeatureGenerator(group_col="gid", n_top_features=100)
+        expected = self._mapped_variance(X.copy(), gen)
+        gen._fit_transform(X.copy(), y)
+        ranked = sorted(expected, key=lambda f: (-gen._rank_variance(expected[f]), f))
+        assert gen._selected_features == ranked[: gen.n_top_features]


### PR DESCRIPTION
## Summary

`GroupAggregationFeatureGenerator._fit_transform` (#528) maps every aggregation of every column back to every row to compute the variances it ranks features by, a rows x columns x aggregations frame that the per-column pass it replaced never built. The variance of a per-group value broadcast to its group's rows is now computed from the group table and the group sizes, so the fit's peak memory is back to the per-column pass's while the single groupby keeps its speed. Selection is unchanged.

<details>
<summary>Details</summary>

Peak RSS of the generator over the data on synthetic frames (numeric and categorical columns, a group key, a time column), each variant in its own process:

| rows x feature columns x groups | before #528 | #528 | this PR |
|---|---|---|---|
| 100k x 120 x 1k | 495 MB / 12.3 s | 1952 MB / 1.6 s | 541 MB / 1.4 s |
| 1M x 25 x 10k | 2.3 GB / 40 s | 4.0 GB / 7.5 s | 2.5 GB / 7.1 s |
| 1M x 120 x 10k | 4.2 GB / 162 s | 18.7 GB / 20 s | 4.5 GB / 17.5 s |

`_broadcast_variance` is the size-weighted sample variance (`ddof=1`, NaN groups skipped); on the 100k x 120 frame it agrees with the mapped `.var()` to a relative 5e-16 across all 565 aggregation features. The ranking now compares variances rounded to 12 significant digits, so two aggregations of identical values (a column's `count` and another's) tie by name instead of by the last bit of two floating-point sums; the per-column reference in the randomized test ranks the same way. `_transform` is unchanged: it maps only the selected features to the rows.

</details>

## Tests

```
ruff check packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py tests/tabarena/benchmark/preprocessing/test_preprocessing.py
ruff format --check <same files>
pytest tests/tabarena/benchmark/preprocessing/test_preprocessing.py -q
```

250 passed (the 60-seed per-column equivalence test included; two new tests for the group-table variance and the ranking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
