### PR TITLE
Read categorical test columns through their codes in the unseen-category transform

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/model_specific_default_preprocessing.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/model_specific_default_preprocessing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+import numpy as np
 import pandas as pd
 from autogluon.common.features.types import (
     R_BOOL,
@@ -181,18 +182,7 @@ class NoCatAsStringCategoryFeatureGenerator(CategoryFeatureGenerator):
             X_category = dict()
             if self.category_map is not None:
                 for column, column_map in self.category_map.items():
-                    col_values = X[column]
-                    known = set(column_map)
-                    # Detect non-NaN values absent from the train-time category set.
-                    is_unseen = col_values.notna() & ~col_values.astype(object).isin(known)
-                    if is_unseen.any():
-                        # Keep the original unseen values by extending the category list with them.
-                        col_values = col_values.astype(object)
-                        unseen_vals = col_values[is_unseen].unique().tolist()
-                        cats: pd.Index = pd.Index(list(column_map) + unseen_vals, dtype=object)
-                    else:
-                        cats = column_map
-                    X_category[column] = pd.Categorical(col_values, categories=cats)
+                    X_category[column] = self._encode_column(X[column], column_map)
                 X_category = pd.DataFrame(X_category, index=X.index)
                 if self._fillna_map is not None:
                     for column, col_fill in self._fillna_map.items():
@@ -200,6 +190,32 @@ class NoCatAsStringCategoryFeatureGenerator(CategoryFeatureGenerator):
         else:
             X_category = pd.DataFrame(index=X.index)
         return X_category
+
+    @staticmethod
+    def _encode_column(col_values: pd.Series, column_map: pd.Index) -> pd.Categorical:
+        """The column as a categorical over the train-time categories, unseen values appended.
+
+        Non-NaN values absent from `column_map` are kept as extra categories, in order of first
+        appearance. A column that already is categorical is read through its codes, so no value
+        is hashed or converted.
+        """
+        known = set(column_map)
+        if isinstance(col_values.dtype, pd.CategoricalDtype):
+            codes = col_values.cat.codes.to_numpy()
+            present = np.asarray(col_values.cat.categories)[pd.unique(codes[codes >= 0])]
+            unseen_vals = [value for value in present.tolist() if value not in known]
+            if not unseen_vals:
+                return col_values.cat.set_categories(column_map).array
+            cats = pd.Index(list(column_map) + unseen_vals, dtype=object)
+            return pd.Categorical(col_values.astype(object), categories=cats)
+        is_unseen = col_values.notna() & ~col_values.astype(object).isin(known)
+        if is_unseen.any():
+            col_values = col_values.astype(object)
+            unseen_vals = col_values[is_unseen].unique().tolist()
+            cats = pd.Index(list(column_map) + unseen_vals, dtype=object)
+        else:
+            cats = column_map
+        return pd.Categorical(col_values, categories=cats)
 
     @staticmethod
     def get_default_infer_features_in_args() -> dict:

--- a/tests/tabarena/benchmark/preprocessing/test_preprocessing.py
+++ b/tests/tabarena/benchmark/preprocessing/test_preprocessing.py
@@ -440,6 +440,45 @@ class TestNoCatAsStringCategoryFeatureGeneratorUnseenHandling:
         assert not pd.isna(X_out["cat"].iloc[2]), "Unseen 'NEW' must not be NaN"
         assert X_out["cat"].astype(object).iloc[2] == "NEW"
 
+    # ------------------------------------------------------------------
+    # The codes-based path for categorical input equals the value-based one
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("with_unseen", [False, True])
+    def test_categorical_input_matches_object_input(self, with_unseen: bool):
+        """A categorical test column is read through its codes; the result must equal the
+        value-based path, including the order in which unseen categories are appended.
+        """
+        rng = np.random.default_rng(0)
+        train_values = np.array(["a", "b", "c", "d"], dtype=object)[rng.integers(0, 4, 200)]
+        X_train = pd.DataFrame({"cat": pd.Categorical(train_values), "num": rng.random(200)})
+        gen = self._fit_gen(X_train)
+        test_values = np.array(["c", "a", None, "b", "a"], dtype=object)
+        if with_unseen:
+            test_values = np.array(["NEW2", "c", "NEW1", None, "NEW2", "a"], dtype=object)
+        as_categorical = pd.DataFrame({"cat": pd.Categorical(test_values), "num": rng.random(len(test_values))})
+        as_object = as_categorical.assign(cat=pd.Series(test_values, dtype=object))
+
+        out_categorical = gen.transform(as_categorical.copy())
+        out_object = gen.transform(as_object.copy())
+
+        pd.testing.assert_frame_equal(out_categorical, out_object)
+        assert list(out_categorical["cat"].cat.categories) == list(out_object["cat"].cat.categories)
+        expected_categories = ["a", "b", "c", "d"] + (["NEW2", "NEW1"] if with_unseen else [])
+        assert list(out_categorical["cat"].cat.categories) == expected_categories
+        values_out = out_categorical["cat"].astype(object).tolist()
+        assert [v if not pd.isna(v) else None for v in values_out] == list(test_values)
+
+    def test_categorical_input_unused_dtype_category_is_not_unseen(self):
+        """A category declared in the test column's dtype but absent from its values is not
+        appended: only values decide, as in the value-based path.
+        """
+        X_train = pd.DataFrame({"cat": pd.Categorical(["a", "b", "a", "b"])})
+        gen = self._fit_gen(X_train)
+        X_test = pd.DataFrame({"cat": pd.Categorical(["a", "b"], categories=["a", "b", "ghost"])})
+        X_out = gen.transform(X_test.copy())
+        assert list(X_out["cat"].cat.categories) == ["a", "b"]
+
     def test_mixed_known_unseen_and_nan(self):
         X_train = pd.DataFrame({"cat": pd.Categorical(["a", "b", "a", "b"])})
         gen = self._fit_gen(X_train)


### PR DESCRIPTION
## Summary

`NoCatAsStringCategoryFeatureGenerator._transform` maps test categories to the fitted ones through the integer codes instead of comparing values through an object column, and only rebuilds the categorical when a column has unseen categories. Outputs are unchanged; the new tests cover unseen categories, missing values and the no-change case.

## Tests

`ruff check` and `ruff format --check` on the two files; `pytest tests/tabarena/benchmark/preprocessing/test_preprocessing.py -q` (253 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi