### PR TITLE
Explain the five-stage submission lifecycle in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,15 @@
 
 <!-- Delete this section if the PR is not a model or system submission. -->
 
-TabArena is not a benchmarking service. We accept methods their authors have already evaluated with the official pipeline and confirm the results by re-running them. A maintainer verifies the submission first, then re-runs the method on the benchmark hardware for the final entry; we are happy to help with the integration and the re-run. Once the method is benchmarked and merged, the leaderboard is updated as soon as possible. See [Contributing a Model or System](https://github.com/autogluon/tabarena#contributing-a-model-or-system).
+TabArena is not a benchmarking service. We accept methods their authors have already evaluated with the official pipeline and confirm the results by re-running them. See [Contributing a Model or System](https://github.com/autogluon/tabarena#contributing-a-model-or-system).
+
+A submission reaches the leaderboard in five stages. This pull request is stage 1; maintainers drive the other four and post in the PR as each one completes, so this thread is the record of the submission.
+
+1. Pull request with the method. You integrate the model or system, run the quick start and the TabArena-Lite evaluation, and open this PR with the checklists below filled in. Reviewers check the wrapper against the protocol (the validation split TabArena passes, time limits, resources, seeds), the dependency pin and license, and the Lite results, and help fix what the review finds.
+2. Benchmark run. Once the review is through, a maintainer runs the method on the full TabArena task set on the benchmark hardware: all splits of every dataset, and for a model the default configuration plus the full search space. Every entrant is measured this way, so your run from stage 1 is never the final entry. The run is recorded in `packages/tabflow_slurm/BENCHMARK_LOG.md` and the maintainer posts the resulting leaderboard position here.
+3. Verification and sign-off. Maintainers compare the run with the Lite results from stage 1 and look into failed splits and time-limit hits; a mismatch goes back to stage 1 or 2 with a fix. Then the person named under "Results" below confirms in the PR that the run reflects the method as intended (the right version, checkpoint and hyperparameters). That confirmation marks the entry as verified on the leaderboard. Without it the entry is still listed, but as unverified.
+4. Upload and merge. The maintainer processes the raw results, hosts the artifacts (results, processed predictions and raw predictions), records the hosted locations and the verification status in the method's `info.py`, registers the method in the arena's method collection, and merges the PR. A merged method therefore always has hosted results behind it.
+5. Leaderboard update. After the merge, the website artifacts are regenerated from the hosted results and the leaderboard is refreshed with a new version entry that names the method. This happens in batches with other new entries, usually within days of the merge.
 
 Kind: <!-- model or system; if it replaces an entrant already on the leaderboard, name it -->
 

--- a/README.md
+++ b/README.md
@@ -120,10 +120,12 @@ results by re-running them.
 4. Open a pull request; the template asks for the expected files, the results, the hardware and the
    entry-point script. You can also share the run's output directory (the `expname` folder with the
    `results.pkl` files) so we can verify and integrate the results directly.
-5. A maintainer verifies the submission and re-runs the method on the benchmark hardware for the
-   final entry. We are happy to help with the integration and the re-run. The authors sign off on the
-   result, which marks the entry as verified.
-6. Once the method is benchmarked and merged, the leaderboard is updated as soon as possible.
+5. A maintainer reviews the pull request, then runs the method on the full task set on the
+   benchmark hardware for the final entry. We are happy to help with the integration and the run.
+6. Maintainers verify that run against your Lite results, and the person you name in the template
+   signs off on it, which marks the entry as verified.
+7. The results are processed, hosted and registered, and the pull request is merged.
+8. The leaderboard is regenerated from the hosted results after the merge, usually within days.
 
 Questions go through the [issue forms](.github/ISSUE_TEMPLATE): one for model and system
 submissions, one for leaderboard or dataset questions that touch this code base. Pure leaderboard


### PR DESCRIPTION
## Summary

The "Model or system submission" section of the pull request template now explains how a submission reaches the leaderboard in five stages: the pull request with the method, the maintainer benchmark run, verification and sign-off, upload and merge, and the leaderboard update. Contributors see up front which stage their PR covers and what maintainers do after it, and the PR thread becomes the record of the stages. The README's submission process list is split the same way so the two stay consistent.

<details>
<summary>Details</summary>

The template kept a two-sentence description of the process, which left contributors asking when the re-run happens, what sign-off means, and when a merged method shows up on the leaderboard. The new numbered list answers those in order and ties each stage to what already exists: the checklists in the template for stage 1, `packages/tabflow_slurm/BENCHMARK_LOG.md` for stage 2, the sign-off person named under "Results" for stage 3 (which sets the verified flag), the hosted artifacts and `info.py` metadata plus the arena method collection for stage 4, and the regenerated website artifacts for stage 5.

In the README, the former steps 5 and 6 (maintainer re-run plus sign-off, then leaderboard update) became steps 5 to 8 with the same split as the template. The issue form's short description of the process still holds and was left unchanged.

Docs only; no code paths change.

</details>

## Tests

Markdown only. Checked the changed lines against the writing rules in AGENTS.md (no em dashes, arrows, double-hyphen pivots or bold-first bullets).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
